### PR TITLE
Added RAG

### DIFF
--- a/Data/reframing_retirement_activity_list.txt
+++ b/Data/reframing_retirement_activity_list.txt
@@ -1,0 +1,725 @@
+#####################
+Local Activities List
+#####################
+
+1. Choose to Move & ActivAge
+What: Group fitness and active aging program
+Where: Crystal Pool and Fitness Centre
+When: Mondays and Fridays
+Cost: Free
+
+********************************************************************
+
+
+2. Aqua Yoga
+What: Water-based yoga
+Where: Crystal Pool and Fitness Centre
+When: Mondays
+Cost: $132 for 11 sessions
+
+********************************************************************
+
+
+3. 55+ Kayaking: Beginner
+What: Beginner kayaking
+Where: Ocean River Downtown Dock
+When: Thursdays
+Cost: $285 for 5 sessions
+
+********************************************************************
+
+
+4. 55+ Kayaking: Intermediate
+What: Intermediate kayaking
+Where: Ocean River Downtown Dock
+When: Thursdays
+Cost: $285 for 5 sessions
+
+********************************************************************
+
+
+5. 55+ Kayaking: Tour Style
+What: Tour-style kayaking
+Where: Ocean River Downtown Dock
+When: Saturdays
+Cost: $285 for 5 sessions
+
+********************************************************************
+
+
+6. Introductory Pickleball
+What: Beginner pickleball
+Where: Oaklands Park
+When: Mondays or Tuesdays
+Cost: $120 for 6 sessions
+
+********************************************************************
+
+
+7. Level 2.0 Pickleball
+What: Intermediate pickleball
+Where: Oaklands Park
+When: Thursdays or Fridays
+Cost: $225 for 6 sessions
+
+********************************************************************
+
+
+8. Gentle Chair Yoga
+What: Chair-based yoga
+Where: Fairfield Gonzales Community Association
+When: Fridays
+Cost: $130 for multiple sessions
+
+********************************************************************
+
+
+9. Hatha Yoga
+What: Traditional yoga
+Where: Fairfield Gonzales Community Association
+When: Thursdays
+Cost: $110 for multiple sessions
+
+********************************************************************
+
+
+10. Iyengar Yoga – Beginner Friendly
+What: Beginner-friendly Iyengar yoga
+Where: Fairfield Gonzales Community Association
+When: Thursdays
+Cost: $144 for multiple sessions
+
+********************************************************************
+
+
+11. Iyengar Yoga – Support and Restore
+What: Restorative Iyengar yoga
+Where: Fairfield Gonzales Community Association
+When: Thursdays
+Cost: $144 for multiple sessions
+
+********************************************************************
+
+
+12. Iyengar Yoga – All Levels Welcome
+What: All-levels Iyengar yoga
+Where: Fairfield Gonzales Community Association
+When: Tuesdays
+Cost: $150 for multiple sessions
+
+********************************************************************
+
+
+13. Seated Dance
+What: Seated dance movement class
+Where: Fairfield Gonzales Community Association
+When: Wednesdays
+Cost: $60 for multiple sessions
+
+********************************************************************
+
+
+14. Somatic Yoga
+What: Somatic movement-based yoga
+Where: Fairfield Gonzales Community Association
+When: Wednesdays
+Cost: $130 for multiple sessions
+
+********************************************************************
+
+
+15. SoQi
+What: Movement and breath-based exercise
+Where: Fairfield Gonzales Community Association
+When: Mondays
+Cost: $120 for multiple sessions
+
+********************************************************************
+
+
+16. Yoga & Pilates – Active Aging
+What: Yoga and Pilates combo
+Where: Fairfield Gonzales Community Association
+When: Wednesdays
+Cost: $156 for multiple sessions
+
+********************************************************************
+
+
+17. Zumba
+What: Dance-based fitness
+Where: Fairfield Gonzales Community Association
+When: Mondays
+Cost: $120 for multiple sessions
+
+********************************************************************
+
+
+18. Zumba Toning
+What: Zumba with strength elements
+Where: Fairfield Gonzales Community Association
+When: Wednesdays
+Cost: $130 for multiple sessions
+
+********************************************************************
+
+
+19. Walking Group (James Bay CC)
+What: Group walking
+Where: James Bay Community Centre
+When: Wednesdays
+Cost: Free
+
+********************************************************************
+
+
+20. Easy Walks
+What: Casual group walks
+Where: Various locations
+When: Mondays
+Cost: Free
+
+********************************************************************
+
+
+21. Walking Group (James Bay School)
+What: Group walking
+Where: James Bay Community School Centre
+When: Wednesdays
+Cost: Free
+
+********************************************************************
+
+
+22. Victoria West Programs Website
+What: Recreation program listings
+Where: Online
+When: Ongoing
+Cost: Varies
+
+********************************************************************
+
+
+23. Free Easy Walks
+What: Guided, social group walks on paved and smooth trails
+Where: Various parks and neighbourhoods (Saanich area)
+When: Mondays, 1:30–2:30 pm (except holidays)
+Cost: Free
+
+********************************************************************
+
+
+24. Pickleball – Adult Drop-In
+What: Drop-in pickleball sessions
+Where: Saanich Commonwealth Place
+When: Monday to Friday, 6:00–8:30 am (Sep 15–Dec 30)
+Cost: $7.75 per drop-in
+
+********************************************************************
+
+
+25. Minds in Motion (50yrs+)
+What: Fitness and social program for individuals with early-stage dementia and a care partner
+Where: Gordon Head Recreation Centre / G.R. Pearkes Recreation Centre
+When: Mondays or Wednesdays, 1:00–2:30 pm (Sep–Dec sessions)
+Cost: $48–$56 (session-based)
+
+********************************************************************
+
+
+26. Spinal Fitness
+What: Gentle spinal mobility and strengthening exercises
+Where: Gordon Head Middle School
+When: Tuesdays, 6:30–7:30 pm (Sep–Dec sessions)
+Cost: $66–$76 (session-based)
+
+********************************************************************
+
+
+27. Walk and Talk
+What: Guided walking program through parks and neighbourhoods
+Where: Various Saanich locations
+When: Tuesdays and Thursdays, 9:30–11:00 am (Sep–Dec)
+Cost: $50 (10x pass) or $105 (unlimited)
+
+********************************************************************
+
+
+28. Cardio Fun
+What: Beginner-friendly cardio fitness class
+Where: Cedar Hill Recreation Centre (Virtual option available)
+When: Wednesdays, 9:15–10:15 am
+Cost: Included with registration
+
+********************************************************************
+
+
+29. Chair Fit
+What: Chair-based strength and mobility class
+Where: Cedar Hill Recreation Centre / G.R. Pearkes Recreation Centre
+When: Fridays or Mondays, late morning
+Cost: Included with registration
+
+********************************************************************
+
+
+30. Easy Fit
+What: Low-intensity fitness for older adults
+Where: Cedar Hill Recreation Centre / G.R. Pearkes Recreation Centre
+When: Multiple weekday options
+Cost: Included with registration
+
+********************************************************************
+
+
+31. Gentle Fit
+What: Gentle full-body fitness class
+Where: Cedar Hill Recreation Centre
+When: Tuesdays
+Cost: Included with registration
+
+********************************************************************
+
+
+32. Yoga – Slow Flow
+What: Slow-paced yoga focusing on flexibility and balance
+Where: Cedar Hill Recreation Centre / G.R. Pearkes Recreation Centre
+When: Thursdays (morning or evening options)
+Cost: Included with registration
+
+********************************************************************
+
+
+33. Meditation – Buddhist
+What: Guided meditation practice
+Where: Cedar Hill Recreation Centre
+When: Tuesdays
+Cost: Included with registration
+
+********************************************************************
+
+
+34. Aging Backwards
+What: Strength and balance training for older adults
+Where: Gordon Head Recreation Centre / Saanich Commonwealth Place
+When: Tuesdays or Thursdays
+Cost: Included with registration
+
+********************************************************************
+
+
+35. Boxing 50yrs+
+What: Non-contact boxing-inspired fitness
+Where: Saanich Commonwealth Place
+When: Sundays
+Cost: Included with registration
+
+********************************************************************
+
+
+36. Yoga and Mobility
+What: Yoga focused on joint mobility and movement
+Where: Saanich Commonwealth Place
+When: Tuesdays or Thursdays
+Cost: Included with registration
+
+********************************************************************
+
+
+37. Zumba Gold
+What: Low-impact dance fitness
+Where: Cedar Hill Recreation Centre / Saanich Commonwealth Place
+When: Mondays or Fridays
+Cost: Included with registration
+
+********************************************************************
+
+
+38. Balance Booster
+What: Balance and fall-prevention exercises
+Where: Saanich Commonwealth Place
+When: Tuesdays and Thursdays
+Cost: Included with registration
+
+********************************************************************
+
+
+39. Balance and Strength
+What: Combined balance and strength training
+Where: Cedar Hill Recreation Centre / Saanich Commonwealth Place
+When: Thursdays or Fridays
+Cost: Included with registration
+
+********************************************************************
+
+
+40. Yoga – Bend It Like Peckham (Gentle)
+What: Gentle yoga emphasizing flexibility
+Where: Saanich Commonwealth Place
+When: Wednesdays
+Cost: Included with registration
+
+********************************************************************
+
+
+41. Yoga – Pelvic Floor
+What: Yoga focused on pelvic floor health
+Where: Saanich Commonwealth Place
+When: Fridays or Mondays
+Cost: Included with registration
+
+********************************************************************
+
+
+42. Build Better Bones
+What: Strength training to support bone health
+Where: Saanich Commonwealth Place
+When: Mondays and Wednesdays
+Cost: Included with registration
+
+********************************************************************
+
+
+43. Chronic Pain / Mild Movement Class
+What: Gentle movement for chronic pain management
+Where: Saanich Commonwealth Place
+When: Tuesdays and Thursdays
+Cost: Included with registration
+
+********************************************************************
+
+
+44. FAME (Stroke Recovery)
+What: Fitness and mobility exercises for stroke recovery
+Where: Saanich Commonwealth Place
+When: Tuesdays and Fridays
+Cost: Included with registration
+
+********************************************************************
+
+
+45. Osteofit Level 1
+What: Osteoporosis-focused strength and balance program
+Where: Cedar Hill Recreation Centre
+When: Mondays, Wednesdays, Fridays
+Cost: Included with registration
+
+********************************************************************
+
+
+46. Osteofit for Life
+What: Ongoing osteoporosis management fitness
+Where: Cedar Hill Recreation Centre
+When: Mondays, Wednesdays, Fridays
+Cost: Included with registration
+
+********************************************************************
+
+
+47. T.I.M.E. (Stroke / Brain Injury)
+What: Task-oriented movement program for neurological recovery
+Where: Cedar Hill Recreation Centre / Gordon Head Recreation Centre
+When: Mondays, Wednesdays, Fridays
+Cost: Included with registration
+
+*********************************************************************
+
+48. Basketball Adult Drop-In
+What: Adult basketball drop-in
+Where: Victoria West Community Centre
+When: Mondays
+Cost: Not listed
+
+********************************************************************
+
+
+49. Chair Fitness
+What: Chair-based fitness
+Where: Silver Threads Centres
+When: Multiple date options
+Cost: $7 per session
+
+********************************************************************
+
+
+50. Functional Fitness
+What: Functional strength and mobility
+Where: Silver Threads Centres
+When: Multiple date options
+Cost: $7 per session
+
+********************************************************************
+
+
+51. Senior Fitness Toolkit
+What: Structured senior fitness program
+Where: Silver Threads Victoria Centre
+When: Mondays
+Cost: $104 for multiple sessions
+
+********************************************************************
+
+
+52. Introduction to Nordic Pole Walking
+What: Nordic walking instruction
+Where: Silver Threads Saanich Centre
+When: Fridays
+Cost: $42 for multiple sessions
+
+********************************************************************
+
+
+53. Outdoor Walking Group
+What: Outdoor group walking
+Where: Silver Threads Saanich Centre
+When: Wednesdays
+Cost: Free
+
+********************************************************************
+
+
+54. Essentrics
+What: Full-body mobility and strength
+Where: Silver Threads Centres
+When: Wednesdays and Thursdays
+Cost: Up to $120 for multiple sessions
+
+********************************************************************
+
+
+55. Gentle Yoga
+What: Gentle yoga
+Where: Silver Threads Centres
+When: Mondays, Wednesdays, and Thursdays
+Cost: Up to $78 for multiple sessions
+
+********************************************************************
+
+
+56. Chair Yoga
+What: Chair-based yoga
+Where: Silver Threads Victoria Centre
+When: Tuesdays and Thursdays
+Cost: Up to $104 for multiple sessions
+
+********************************************************************
+
+
+57. Power Hour
+What: Higher-intensity fitness class
+Where: Silver Threads Victoria Centre
+When: Thursdays
+Cost: $91 for multiple sessions
+
+********************************************************************
+
+
+58. Line Dance: Beginner
+What: Beginner line dancing
+Where: Silver Threads Saanich Centre
+When: Wednesdays
+Cost: Up to $80 for multiple sessions
+
+********************************************************************
+
+
+59. Line Dance: Beginner Plus
+What: Beginner-plus line dancing
+Where: Silver Threads Saanich Centre
+When: Wednesdays
+Cost: Up to $80 for multiple sessions
+
+********************************************************************
+
+
+60. Line Dance: Intermediate
+What: Intermediate line dancing
+Where: Silver Threads Saanich Centre
+When: Wednesdays
+Cost: Up to $80 for multiple sessions
+
+********************************************************************
+
+
+61. Zumba Gold
+What: Low-impact Zumba
+Where: Silver Threads Saanich Centre
+When: Fridays
+Cost: $91 for multiple sessions
+
+********************************************************************
+
+
+62. Qigong
+What: Qigong movement practice
+Where: Silver Threads Victoria Centre
+When: Thursdays
+Cost: $105 for multiple sessions
+
+********************************************************************
+
+
+63. Pickleball and Sports
+What: Pickleball and sport drop-in
+Where: Silver Threads Saanich Centre
+When: Monday to Friday
+Cost: Up to $7 per session
+
+********************************************************************
+
+
+64. Improve Your Table Tennis
+What: Table tennis skill development
+Where: Silver Threads Saanich Centre
+When: Thursdays
+Cost: $91 for multiple sessions
+
+********************************************************************
+
+
+65. Zumba Standing Gold (Online)
+What: Online Zumba Gold
+Where: Online
+When: Mondays
+Cost: Free
+
+********************************************************************
+
+
+66. Walk It Out Wednesdays / Toning (Online)
+What: Online walking and toning
+Where: Online
+When: Wednesdays
+Cost: Free
+
+********************************************************************
+
+
+67. ChairOne Fitness (Online)
+What: Online seated fitness
+Where: Online
+When: Fridays
+Cost: Free
+
+********************************************************************
+
+
+68. Getting Started With Exercise 50+
+What: Introductory exercise program
+Where: Cedar Hill Gallery Café
+When: Multiple class options
+Cost: $7.50 per session
+
+********************************************************************
+
+
+69. Seniors Table Tennis Reserved Drop-In
+What: Reserved table tennis
+Where: Cedar Hill Gymnasium
+When: Multiple date options
+Cost: $7.75 per session
+
+********************************************************************
+
+
+70. Chair Fit (Active Aging)
+What: Chair-based fitness
+Where: G.R. Pearkes Gardom Room
+When: Multiple date options
+Cost: $49 for 7 sessions
+
+********************************************************************
+
+
+71. Easy Fit
+What: Low-intensity fitness
+Where: G.R. Pearkes Ross Room
+When: Multiple date options
+Cost: $49 for 7 sessions
+
+********************************************************************
+
+
+72. Older Adult Neurodiversity Social & Movement (55+)
+What: Social and movement class
+Where: Social Centre Room
+When: Wednesdays
+Cost: $100 for 10 sessions
+
+********************************************************************
+
+
+73. Getting Started With Exercise 50+ (AG)
+What: Introductory exercise class
+Where: G.R. Pearkes Ross Room
+When: Multiple date options
+Cost: $7 per session
+
+********************************************************************
+
+
+74. Social Chair Fitness (55+)
+What: Social chair-based fitness
+Where: Cedar Hill Multi-Purpose Room
+When: Tuesdays
+Cost: $30 for 6 sessions
+
+********************************************************************
+
+
+75. Weight Room Orientation (60+)
+What: Weight room orientation
+Where: Saanich Commonwealth Place
+When: Multiple date options
+Cost: $15 or Free
+
+********************************************************************
+
+
+76. Weight Training – Beginner 50+
+What: Beginner weight training
+Where: G.R. Pearkes Gardom Room
+When: Mondays
+Cost: $70 for 7 sessions
+
+********************************************************************
+
+77. Oak Bay Recreation – Swimming & Aquafit (Drop-in)
+What: Drop-in swimming and aquafit sessions available with Oak Bay Recreation admission or pass
+Where: Oak Bay Recreation Centre (swimming) / Monterey Recreation Centre (separate membership)
+When: Various days and times (see Oak Bay Recreation schedules)
+Cost: Included with Oak Bay Recreation admission or pass
+Notes: Admission/pass includes access to swimming, group fitness, skating, and drop-in sports (excluding golf and tennis). Monterey drop-ins require a separate Monterey membership.
+
+********************************************************************
+
+
+78. Oak Bay Recreation – Group Fitness (Drop-in)
+What: Drop-in strength, cardio, and movement classes
+Where: Oak Bay Recreation Centre (group fitness) / Monterey Recreation Centre (separate membership)
+When: Various days and times (see Oak Bay Recreation schedules)
+Cost: Included with Oak Bay Recreation admission or pass
+Notes: Admission/pass includes access to swimming, group fitness, skating, and drop-in sports (excluding golf and tennis). Monterey drop-ins require a separate Monterey membership.
+
+********************************************************************
+
+
+79. Oak Bay Recreation – Racquet Sports (Drop-in)
+What: Drop-in racquet sport opportunities (excluding golf and tennis)
+Where: Oak Bay Recreation Centre (drop-in racquet spaces)
+When: Various days and times (see Oak Bay Recreation schedules)
+Cost: Included with Oak Bay Recreation admission or pass
+Notes: Admission/pass includes access to swimming, group fitness, skating, and drop-in sports (excluding golf and tennis).
+
+********************************************************************
+
+
+80. Oak Bay Recreation – Skating & Duffer Hockey (Drop-in)
+What: Drop-in skating and duffer hockey sessions
+Where: Oak Bay Recreation Centre ice
+When: Various days and times (see Oak Bay Recreation schedules)
+Cost: Included with Oak Bay Recreation admission or pass
+Notes: Admission/pass includes access to swimming, group fitness, skating, and drop-in sports (excluding golf and tennis).
+
+
+<<<<<<<<<<<<<<<<<<<<<<<<<END OF LIST>>>>>>>>>>>>>>>>>>>>>>>>>>>>

--- a/Data/reframing_retirement_master_data_set.txt
+++ b/Data/reframing_retirement_master_data_set.txt
@@ -1,0 +1,2480 @@
+$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
+SECTION 1: Why to be Active | M-PAC Reflective Processes Layer 
+$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
+
+=====================================================================
+LESSON 1: Why Physical Activity Matters During Retirement (29 slides)
+=====================================================================
+L01-S01-G001 | Lesson 1 Slide 1/29 | Global 1/271
+
+Lesson Description: This lesson shows why physical activity is important during retirement and how it benefits your health, independence, and quality of life.
+
+********************************************************************
+L01-S02-G002 | Lesson 1 Slide 2/29 | Global 2/271
+
+Title: What M-PAC says: Instrumental Attitude
+
++++
+
+Content: 
+Reflective processes are the foundation for forming your intentions to be active.They involve the thoughts and evaluations you make about being physically active. A key part of these reflective processes is your instrumental attitude (- the beliefs you hold about how activity will benefit you and what positive outcomes you expect. This is where you consider the advantages and disadvantages of being active [1,2]. For example: You might believe that walking every morning will help you keep your joints flexible, manage your weight, and feel more energetic during retirement.Or you might think that joining a local fitness class will help you meet new people and stay socially connected. These positive expectations build your motivation to get started, they help you decide why physical activity is worth your time and effort as you settle into retirement.
+
+*********************************************************************
+L01-S03-G003 | Lesson 1 Slide 3/29 | Global 3/271
+
+Title: What is physical activity?
+
++++
+
+Content:
+Physical activity means any movement of your body that uses energy. The World Health Organization describes it as “any bodily movement produced by your muscles that requires energy expenditure [3].” This includes all kinds of movement - not just workouts or sports. 
+Converted image: Leisure activities like walking, swimming, or cycling. Active travel, such as walking or wheeling to the store. Domestic Activities like cleaning, gardening, or home repairs. Enjoyable movement, like dancing, playing with grandchildren or joining a recreation group.
+Physical activity can happen anywhere at home, outdoors, or in your community. It can look different for everyone, depending on your health, mobility, and interests. Every move counts, from stretching or lifting groceries to walking, dancing, or using resistance bands to build strength.
+
+*********************************************************************
+L01-S04-G004 | Lesson 1 Slide 4/29 | Global 4/271
+
+Title: Let’s talk intensity
+
++++
+
+Content: 
+Physical activity can look and feel different for everyone. Some activities make your heart beat faster, others build strength or balance -and they all work together to support healthy aging [4].
+Converted image: Light activity: Movement that feels easy and comfortable. You can talk easily and aren’t short of breath. Light physical activity is movement that does not result in sweating or shortness of breath (e.g., slow walking, stretching, light gardening). Moderate to vigorous physical activity: Movement that is intense enough to increase your heart rate and elevate your body temperature (e.g., running, jumping rope, tennis, swimming). Muscle-strengthening activities: Activities that increase skeletal muscle strength, power, endurance, and mass (e.g., resistance training and heavy gardening involving digging or shovelling). Bone-strengthening activities produce an impact or tension force on the bones that promotes bone growth and strength (e.g., running, jumping rope, and lifting weights). What about balance? Static and dynamic balance exercises are designed to improve your ability to maintain balance while walking on their own or in a crowd, in bad weather, while climbing up and down steps, or opening heavy doors. Activities that improve balance include walking on uneven ground (e.g., unpaved areas, forest trails), Tai Chi, and yoga.
+
+*********************************************************************
+L01-S05-G005 | Lesson 1 Slide 5/29 | Global 5/271
+
+Title: What the evidence shows
+
++++
+
+Content: 
+According to the World Health Organization [3], for adults and older adults, regular physical activity is associated with: Reduced risk of all cause mortality. Lower risk of cardiovascular disease, hypertension, type 2 diabetes, and certain cancers. Fewer falls and fall-related injuries. Improved mental health, cognitive injuries, sleep quality and body composition.Being active helps you stay healthier for longer. It supports your heart, strengthens your muscles and bones, protects your mind, and improves how you feel day to day. Regular movement lowers your chances of developing chronic diseases, helps prevent falls, and can boost your energy, mood, and sleep, making it easier to enjoy life and stay independent as you age [5].
+
+*********************************************************************
+L01-S06-G006 | Lesson 1 Slide 6/29 | Global 6/271
+
+Title: Why this matters now
+
+
++++
+
+Content: 
+Retirement is natural part of life. With it can come new routine but also challenges like aches and pains, cognitive decline, higher risk for chronic conditions, and in some cases, social isolation. On the bright side! Being physically active can help you stay strong, mentally fit, and independent. How can physical activity help as I transition into retirement?
+Physical activity becomes extremely important as we enter into retirement and beyond, especially in these three key areas: Increased mobility: Falls remain the leading cause of injury-related hospitalizations among older adults living in Canada. Between 20% and 30% of older adults fall each year [6]. Thankfully, engaging in activities such as strength training or taking a brisk walk are excellent ways to not only clock some of the recommended 150 minutes of moderate-to-vigorous physical activity per week but also to improve balance, core strength, and stability — three absolute game-changers when it comes to preventing falls. Cognitive wellness: A recent report projects that by 2031, close to 1.4 million adults living in Canada will be affected by dementia, resulting in direct health-care costs of approximately $16.6 billion [7]. Because the primary risk factor for dementia is age, the number of people in Canada living with a related brain disorder is expected to grow. Regular physical activity! Research shows that being physically active protects against the onset of dementia and can slow its progression [8]. So when you get out there and get active, you’re not only keeping your body healthy but your mind, too. Connection and community: Research indicates that one in five adults living in Canada experience some level of loneliness or isolation [6]. The most at risk? Older adults due to reduced mobility, increased risk of fall-related injuries, and shrinking social networks. Engaging in regular physical activities or exercise and socializing that make us feel happier also provides the chance to meet new people and connect with friends — both of which help prevent cognitive decline while keeping our brains healthy.
+
+*********************************************************************
+L01-S07-G007 | Lesson 1 Slide 7/29 | Global 7/271
+
+Title: Why fitness matters more than you think
+
++++
+
+Content:
+Graph: The graph shows the percentage of disease burden attributable to different risk factors in men and women, with low cardiorespiratory fitness (CRF) contributing the largest share for both sexes. The higher the bar, the more deaths can be attributed to each factor. As you can see, low CRF (cardiorespiratory fitness) is correlated with more deaths than obesity, smoking, hypertension (high blood pressure), high cholesterol, or diabetes. This means that physical inactivity is a bigger killer than other conditions such as obesity, smoking, hypertension, high cholesterol, diabetes. Based on this graph, can you imagine the positive health impacts increasing physical activity could have on our society?
+
+*********************************************************************
+L01-S08-G008 | Lesson 1 Slide 8/29 | Global 8/271
+
+Title: Did you know?
+
+C
++++
+
+Content: 
+Exercise reduces the risk of premature death and the onset of over 25 major chronic diseases, including coronary heart disease, cancer, diabetes, and even some types of brain disease [9]. For example, exercise affects brain chemistry in ways that can help prevent the degeneration and cognitive loss associated with diseases such as Alzheimer’s [10].As you age, regular exercise is also vital for maintaining your strength and balance, which can in turn help prevent injuries [11].
+
+*********************************************************************
+L01-S09-G009 | Lesson 1 Slide 9/29 | Global 9/271 
+
+Title: What the evidence shows
+
++++
+
+Content:
+Regular activity reduces your risk from conditions like diabetes, heart disease, or high blood pressure-even if you already have them. 
+Graph: This graph highlights that lower physical fitness (fewer METs) is associated with a substantially higher relative risk of death across multiple chronic conditions, underscoring the critical importance of maintaining higher fitness levels for long-term health and survival.
+Staying active lowers your risk, even if you smoke, have high blood pressure, or carry extra weight.
+This graph [9] shows that physical activity is a powerful medicine for various chronic diseases. People who have a higher level of fitness (represented in dark blue), have a decreased relative risk of death compared to those with lower fitness levels (represented in green and blue). This effect exists for hypertension, chronic obstructive pulmonary disease (COPD), diabetes, smoking, elevated body mass index, and elevated cholesterol levels (TC). You may be leaving the workforce, but staying active helps you keep your independence, energy, and health.
+
+*********************************************************************
+L01-S10-G010 | Lesson 1 Slide 10/29 | Global 10/271
+
+Title: Active vs inactive: the everyday health impact
+
++++
+
+Content:
+An active lifestyle doesn’t just keep you moving, it impacts everything from your energy to your sleep! Here’s how the benefits stack up compared to being inactive: Higher energy, stronger joints, better mood, improved sleep, less fatigue, better mobility, less sleep issues, reduced chronic pain.
+
+*********************************************************************
+L01-S11-G011 | Lesson 1 Slide 11/29 | Global 11/271
+
+Title: Is it ever to late to start exercising
+
++++
+
+Content:
+Transcribed from video: Is it ever too late to start an exercise program? Absolutely not. It doesn’t matter what your current fitness level is or how old you are—the benefits of exercise are undeniable. There are two important things to keep in mind. First, you need to set reasonable goals and gradually ramp things up. This approach sets you up for success and helps reduce the risk of injury. A strong exercise program is built on four key pillars: Stability training – This helps prevent falls and supports functional fitness, allowing you to move confidently in daily life. Resistance training – Strength training helps combat the natural loss of muscle that comes with aging. Muscle is often called the organ of longevity because of how important it is for long-term health. Cardiovascular training – Measures like VO₂ max, which reflect how efficiently your heart works, are direct predictors of longevity. Cardio exercise is also one of the few things proven to maintain and improve cognitive function and mental health. Nutrition – A solid nutrition program provides the building blocks your body needs to adapt, recover, and succeed. Starting can be hard. Staying consistent can be hard. But becoming frail is hard too. Living without strength is hard. Choosing movement is choosing the better kind of hard.
+
+*********************************************************************
+L01-S12-G012 | Lesson 1 Slide 12/29 | Global 12/271
+
+Title: How much physical activity do I need? [12]
+
++++
+
+Content: 
+For health benefits, adults - including those aged 65 and older - should be physically active every day, minimize sedentary time, and get enough good-quality sleep. 
+From Image: Move often: Aim to be physically active on a regular basis. Try to get at least 150 minutes of moderate-to-vigorous activity each week, such as brisk walking, swimming, or cycling. Include muscle-strengthening activities at least twice per week, like lifting weights, using resistance bands, or doing physically demanding tasks such as heavy gardening. On top of that, add several hours of light physical activity throughout the day—things like gentle walking, stretching, or standing all count. Reduce sedentary time: Try to limit sitting to eight hours or less per day. Keep recreational screen time to no more than three hours per day, and whenever possible, break up long periods of sitting by standing, stretching, or moving around. Sleep well: Aim for 7–9 hours of good-quality sleep each night, with consistent bedtimes and wake-up times. Rest and recovery are not optional—they’re an essential part of staying active and maintaining a healthy lifestyle.
+
+*********************************************************************
+L01-S13-G013 | Lesson 1 Slide 13/29 | Global 13/271
+
+Title: How can I be active?
+
++++
+
+Content:
+How can I be active? The Canadian 24-Hour Movement Guidelines emphasize being active in many ways — not just through exercise [12].Be active through a variety of activities: Sport: pickleball, softball Recreation: biking for fun, frisbee golf, Active transport: walking or cycling to work • Exercise: resistance training, running. Include a mix of: Weight-bearing (walking, step aerobics) and non–weight-bearing (swimming, cycling) activities, Moderate-to-vigorous (hiking, Zumba) and light-intensity (yoga) movement • Structured (soccer league, tennis tournament) and unstructured (dancing, playing with your grandchildren) activities. Be active in different places: Indoors or outdoors: green spaces, parks, waterways, At home, work, or in your community: active breaks, walking meetings, playing with your dog or child, Be active in different contexts: Leisure: dance classes, fishing Transportation: cycling to the store • Household: gardening or chores
+
+*********************************************************************
+L01-S14-G014 | Lesson 1 Slide 14/29 | Global 14/271
+
+Title: How much physical activity gives the most benefit?
+
++++
+
+Content: 
+
+Research shows that any amount of movement is better than none, and the greatest health gains occur when you move from being inactive to doing some activity. The figure below shows how health and fitness benefits increase as physical activity levels rise, with the biggest improvements happening between 150 and 300 minutes of moderate-to-vigorous physical activity per week [3]. Even small increases in activity, such as short walks or active daily tasks, contribute to better heart health, reduced disease risk, and improved mental well-being. There’s no lower limit for benefit - every move counts, and most of the gains occur early, when you start moving more regularly.
+
+*********************************************************************
+L01-S15-G015 | Lesson 1 Slide 15/29 | Global 15/271
+
+Title: Did you know?
+
++++
+
+Content:
+Combining aerobic activity and strength training provides the greatest health benefits. Research shows that adults who include both types of activity each week have the lowest risk of early death, as well as reduced risk of heart disease, cancer, and diabetes. Even adding just one or two strength-training sessions to a regular aerobic routine can lower the risk of chronic disease by 10–20%. Aerobic activities—such as walking, cycling, or swimming—help keep your heart and lungs strong. Strength training—like resistance exercises or heavy gardening—helps maintain healthy muscles and bones. Together, these two forms of movement create the most effective foundation for long-term health, independence, and quality of life.
+
+*********************************************************************
+L01-S16-G016 | Lesson 1 Slide 16/29 | Global 16/271
+
+Title: What the evidence shows
+
++++
+
+Content: Strength-promoting exercise: A study using large population data (11 cohorts; more than 80,000 adults) found that doing strength-promoting exercise(like gym-based or body-weight strength training) is linked to a lower risk of dying.
+The study found that the benefits of strength exercise still hold true even among people with different lifestyle or health profiles — whether or not they smoke, drink, are older, or have a higher body weight. Key findings [14]: Doing any amount of strength training is associated with a 23% lower risk of death from any cause and a 31% lower risk of death from cancer. Meeting the strength-training guideline of at least two sessions per week is linked to an even greater benefit, including a 21% reduction in all-cause mortality and a 34% reduction in cancer mortality. Meeting aerobic activity guidelines alone—about 150 minutes per week—is also beneficial, reducing all-cause mortality by 16% and cardiovascular mortality by 22%. However, the lowest risks of death are seen in people who meet both aerobic and strength-training guidelines, highlighting the importance of combining these two types of activity for optimal health and longevity. Strength training offers unique health benefits, particularly for reducing the risk of cancer and early death. The best protection comes from combining regular aerobic activity with at least two strength sessions each week.
+
+*********************************************************************
+L01-S17-G017 | Lesson 1 Slide 17/29 | Global 17/271
+
+Title: How active are Canadians?
+
++++
+
+Content: 
+You’re not alone if you find it hard to meet the physical activity guidelines - many adults across Canada are in the same boat.
+Here’s what the numbers show [4]: Among adults aged 18 to 79 in Canada, 49% take at least 7,500 steps per day. Similarly, 49% of adults aged 18–79 meet the guideline of at least 150 minutes of moderate-to-vigorous physical activity per week. Looking specifically at aerobic activity, 53% of adults aged 18–64 achieve at least 150 minutes per week, compared with only 28% of adults aged 65–79, showing a noticeable drop in activity with age. When it comes to strength training, participation is much lower. Only 1 in 4 adults meet the recommendation to do muscle-strengthening activities at least twice per week. Even small increases in movement can make a difference for your health - every step, stretch, or strength session counts.
+
+*********************************************************************
+L01-S18-G018 | Lesson 1 Slide 18/29 | Global 18/271 
+
+Title: What can I Do?
+
++++
+
+Content:
+When it comes to physical activity and its benefits, every step counts [15]. There are many enjoyable ways to take steps toward improving your health and well- being. The key is to find what moves you [16]. For instance, you might: go for a walk with a neighbour or friend, explore a local park or nature trail, dance around the kitchen while making dinner, walk your dog, or join a community walking group or try 'active travel' by walking, wheeling or cycling for short errands. Fun facts: Among women aged 62 and older, step count and moderate-to-vigorous physical activity are similarly linked to lower risk of early death and cardiovascular disease [17].Taking as few as 2600 steps per day is associated with a lower risk of dying from any cause [15].
+Outdoor, nature based activities can help you get your steps while boosting mood and connection with the environment [18].
+
+*********************************************************************
+L01-S19-G019 | Lesson 1 Slide 19/29 | Global 19/271
+
+Title: The ripple effect of a walk
+
++++
+
+Content:
+Choosing walking or cycling instead of driving helps reduce air pollution, traffic noise, and carbon emissions. Replacing just one typical gasoline-powered passenger vehicle trip with walking or cycling can save approximately 0.21 kilograms of carbon dioxide (CO₂). When more people walk or cycle on roads, it also makes neighbourhoods feel safer, more social, and more vibrant, helping create communities where people feel comfortable spending time outdoors. In short, choosing active transportation doesn’t just benefit your health—it also supports a cleaner environment and stronger, more connected communities.
+
+*********************************************************************
+L01-S20-G020 | Lesson 1 Slide 20/29 | Global 20/271
+
+Title: Engaging in moderate-to-vigorous activity. 
+
++++
+
+Content:
+There are many ways to get your heart and blood pumping throughout the day, it doesn’t have to mean going to the gym! Try activities like: Riding an e-bike or cycle around your neighbourhood, playing pickleball, tennis, or another sport you enjoy, or choose activities like wheeling, brisk walking, climbing stairs, Joining a fitness class, swimming, or dancing to your favourite music. The goal is to move in ways that make you breathe harder, feel warmer, and raise your heart rate — even for short bursts. Fun facts: A quicker walking pace is linked to a lower risk of early death, even after accounting for total daily steps [19]. Among Canadians living with multiple chronic conditions, those who are physically active report greater life satisfaction than those who are inactive [20]. Check out the resource section for ideas on ways to be active at home, outdoors or in the community.
+
+*********************************************************************
+L01-S21-G021 | Lesson 1 Slide 21/29 | Global 21/271
+
+Title: Don't forget muscle-strengthening activities!
+
++++
+
+Content:
+There’s no single “best” way to build muscle or strength. While heavier loads and multiple sets can help increase muscle size and strength, most combinations of load, sets, and repetitions provide meaningful benefits [21]. Even stretching can lead to small improvements in strength and flexibility [22]. The key is to find a type of movement you enjoy and can stick with - whether that’s lifting weights, using resistance bands, or doing body-weight exercises like squats, wall push-ups, or yoga. Fun fact:Doing any resistance training is associated with: 15% lower risk of all-cause mortality, 19% lower risk of cardiovascular mortality, 14% lower risk of cancer mortality [23]. Check out the resource section for ideas on simple strength exercises you can do at home or in your community.
+
+*********************************************************************
+L01-S22-G022 | Lesson 1 Slide 22/29 | Global 22/271
+
+Title: Include balance activities
+
++++
+
+Content:
+There are many ways to play with balance - it doesn’t have to feel like exercise! You might: Tango with a partner, Join a friend in the park for yoga or tai chi, Find a bowling league or community dance group, Play exergames with your grandkids that challenge your balance and coordination. Meeting the recommendations for balance activities — even independent of meeting MVPA guidelines — is associated with better perceived health [24]. Balance-focused activities can help people discover enjoyable new ways to stay active and confident on their feet.Fun facts: In addition to structured exercises or balance equipment (e.g., balance (training pad), great options include dancing, tai chi, yoga, or exergames that involve shifting your weight [25,26]. Research shows that creative, folk, and ballroom dance can improve balance and reduce fall risk among adults aged 60+ - including those living with Parkinson’s disease [25]. Check out the resources section for fun and accessible balance activities you can try at home or in your community.
+
+*********************************************************************
+L01-S23-G023 | Lesson 1 Slide 23/29 | Global 23/271
+
+***DO NOT REFERENCE***
+
+Title: Reflection
+
+*********************************************************************
+L01-S24-G024 | Lesson 1 Slide 24/29 | Global 24/271
+
+Title: Main lesson takeaways
+
++++
+
+Content:
+Here are the main takeaway points from the lesson: 1. Every move counts. You don’t need to “work out” – all movement matters, from stretching to brisk walking to dancing. 2. Mix it up. Include a variety of activities – aerobic, strength, and balance – to support your heart, muscles, and confidence. 3. Start where you are. The biggest health gains happen when you move from doing little or nothing to doing something. 4. Stay consistent. Regular activity helps protect your mind and body – supporting your health, independence, and quality of life well into later years.
+
+*********************************************************************
+L01-S25-G025 | Lesson 1 Slide 25/29 | Global 25/271
+
+***DO NOT REFERENCE***
+
+Title: Quiz Question
+
+*********************************************************************
+L01-S26-G026 | Lesson 1 Slide 26/29 | Global 26/271
+
+***DO NOT REFERENCE***
+
+Title: Quiz Question
+
+*********************************************************************
+L01-S27-G027 | Lesson 1 Slide 27/29 | Global 27/271
+
+***DO NOT REFERENCE***
+
+Title: Quiz Question
+
+*********************************************************************
+L01-S28-G028 | Lesson 1 Slide 28/29 | Global 28/271
+
+***DO NOT REFERENCE***
+
+Title: References
+
+*********************************************************************
+L01-S29-G029 | Lesson 1 Slide 29/29 | Global 29/271
+
+***DO NOT REFERENCE***
+
+Title: lesson complete
+
+=================================================================================
+LESSON 2: Feel Better, Think Sharper - The Power of Physical Activity (27 slides)
+=================================================================================
+L02-S01-G030 | Lesson 2 Slide 1/27 | Global 30/271
+
+Lesson Description: This lesson explores how physical activity can boost your mood, reduce feelings of stress or worry, and help keep your mind sharp and focused as you move through retirement.
+
+********************************************************************
+L02-S02-G031 | Lesson 2 Slide 2/27 | Global 31/271
+
+Title: What M-PAC says: Instrumental Attitude
+
++++
+
+Content:
+Reflective processes are the starting point for setting your intentions to be active. They include the different thoughts, evaluations, and beliefs you have about being physically active [1,2]. One part of reflective processes is your instrumental attitude your expectations about what physical activity will do for you, such as how it may improve your mood, well-being, or day-to-day life. This is where you weigh up the pros and cons and consider the benefits you might gain. For example: You might expect that a daily walk will help you feel calmer, reduce stress, and boost your mood. Or you may believe that joining a group class will help you feel more socially connected and supported. These positive beliefs contribute to why you intend to be active. They help you decide that movement is worthwhile because of how it can support your emotional well-being, confidence, and overall quality of life during retirement.
+
+********************************************************************
+L02-S03-G032 | Lesson 2 Slide 3/27 | Global 32/271
+
+Title: Adjusting to new chapters in life
+
++++
+
+Content:
+You may have already thought a lot about how you’ll spend your free time after finishing your career. There’s also a good chance you may have not thought much about the psychological effect the retirement can have on you.
+
+********************************************************************
+L02-S04-G033 | Lesson 2 Slide 4/27 | Global 33/271
+
+Title: The hidden challenges of more free time 
+
++++ 
+
+Content:
+Some issues that accompany the retirement, like having more free time, can be welcomed. At first, there may be a feeling of freedom, like you’re on a vacation that will never end. But other aspects of your new life can make for a difficult adjustment.
+Some retirees experience mental health issues (like depression and anxiety), after they’ve stopped working or after their children leave the family home. When the sense of novelty and freedom wears off, and you may find yourself unsettled by a slower paced lifestyle. There might be a stage that includes anxiety and boredom. You might even feel guilty for not enjoying your free time as much as you think you should
+
+********************************************************************
+L02-S05-G034 | Lesson 2 Slide 5/27 | Global 34/271
+
+Title: Healthy ways to navigate change
+
++++
+
+Content:
+If you’re in the early stages of retirement and feeling somewhat lost, you’re not alone. Many people find these transitions can be difficult. Luckily there are healthy ways to deal with those feelings. You might find walking, going to the gym or a fitness class with others, or yoga helps you deal with your emotions.
+
+********************************************************************
+L02-S06-G035 | Lesson 2 Slide 6/27 | Global 35/271 
+
+***DO NOT REFERENCE***
+
+Title: True or False Question
+
+********************************************************************
+L02-S07-G036 | Lesson 2 Slide 7/27 | Global 36/271 
+
+***DO NOT REFERENCE***
+
+Title: True or False Question
+
+********************************************************************
+L02-S08-G037 | Lesson 2 Slide 8/27 | Global 37/271 
+
+***DO NOT REFERENCE***
+
+Title: True or False Question
+
+********************************************************************
+L02-S09-G038 | Lesson 2 Slide 9/27 | Global 38/271 
+
+Title: What is mood? 
+
++++
+
+Content:
+Think of mood as your overall emotional “background music.” It’s that steady state of feeling, whether happy, calm, sad, or anxious, that hums along in the background of your day. Unlike those quick flashes of emotion, like when you suddenly get irritated in traffic or light up with excitement over good news, mood lingers. It can last for hours, or sometimes even days, shaping the tone of everything you do. Because it sticks around, mood has a big impact on how you think, how you view the world, and even how you connect with the people around you. And here’s the thing: everyone goes through shifts in mood. It's completely normal to have ups, downs and everything on between, it's just a part of being a human being!
+
+********************************************************************
+L02-S10-G039 | Lesson 2 Slide 10/27 | Global 39/271
+
+Title: Did you know?
+
++++
+
+Content:
+Physical activity can have a huge influence on short term mood. When comparing pre-exercise and post-exercise, there is evidence that a bout of exercise can cause a positive change in mood! [3]
+
+********************************************************************
+L02-S11-G040 | Lesson 2 Slide 11/27 | Global 40/271
+
+Title: Anxiety and depression explained
+
++++
+
+Content: 
+Anxiety: A state of worry, nervousness, or unease. It can affect your sleep, focus, and energy. Occasional anxiety is normal, but ongoing anxiety can make daily life more difficult. Depression: More than just sadness. It’s a persistent low mood or loss of interest in things you usually enjoy. Depression can affect your motivation, sleep, appetite, and overall energy.
+
+********************************************************************
+L02-S12-G041 | Lesson 2 Slide 12/27 | Global 41/271 
+
+Title: How physical activity helps anxiety and depression
+
++++
+
+Content: 
+Physical activity can play a powerful role in easing anxiety. It helps lower stress hormones, activates the body’s relaxation response, and improves sleep... All of which make it easier to manage feelings of worry or nervousness. Even something as simple as a short walk can reduce tension and provide a sense of calm, making physical activity a practical tool for coping with anxious moments [4,5]. For depression, physical activity supports mood by triggering the release of brain chemicals like endorphins and serotonin, which help improve our mood. Regular movement also promotes better brain function and emotional balance over time. These effects mean that physical activity isn't just good for the body, it can also be an effective way to lift mood and build resilience against depressive symptoms [4,5].
+
+********************************************************************
+L02-S13-G042 | Lesson 2 Slide 13/27 | Global 42/271 
+
+Title: Physical activity and depression
+
++++
+
+Content:
+Most of us know someone who is or has been diagnosed with depression at some point in their life. In fact, 1 in 10 North Americans will have depression at a given time in their life, and major depression is predicted to be the leading cause of disease by the year 2030 [6,7].This, coupled with the fact that major depression is also associated with increased mortality and severe functional impairment, suggests the importance of prevention and treatment of depression [7].
+
+********************************************************************
+L02-S14-G043 | Lesson 2 Slide 14/27 | Global 43/271
+
+Title: What the evidence shows
+
++++
+
+Content: 
+Luckily, research has demonstrated that regular exercise can be an effective and side-effect free treatment for depression [8]! Exercise also improves symptoms of those with anxiety, acts as a protective mechanism for reducing your risk of developing depression [9,10]. In fact, physical activity has been shown to be just as effective as antidepressants, and more effective at preventing recurrence of depression over time [11]
+
+********************************************************************
+L02-S15-G044 | Lesson 2 Slide 15/27 | Global 44/271 
+
+Title: Benefits at every intensity 
+
++++
+
+Content:
+Interestingly, research has also determined that these benefits of exercise for people with depression and anxiety are present regardless of the intensity you’re exercising at [12]. That means, whether you’re just doing some light gardening, taking a brisk walk in the park, or going for your evening run, you are gaining the preventative benefits exercise has to offer.
+
+********************************************************************
+L02-S16-G045 | Lesson 2 Slide 16/27 | Global 45/271 
+
+Title: Did you know 
+
++++
+
+Content:
+Lower cardiorespiratory fitness levels are associated with a 75% increased risk of developing depression, while those with a medium level of cardiorespiratory fitness only have a 23% increased risk. This means the more active you are, the lower your risk of depression [13].
+
+********************************************************************
+L02-S17-G046 | Lesson 2 Slide 17/27 | Global 46/271 
+
+Title: What is well-being?
+
++++
+
+Content:
+Well-being isn’t just about how our bodies feel, it’s also about how our minds work and how we view ourselves. Let’s focus on these four types of well-being: Physical well-being: Having energy, mobility, and overall good health. Cognitive well-being: Mental skills like memory, focus, and decision-making. Emotional well-being: Mood, resilience, and the ability to handle stress. Self-esteem: Feeling good about yourself and your abilities, which helps confidence in daily life.
+
+********************************************************************
+L02-S18-G047 | Lesson 2 Slide 18/27 | Global 47/271
+
+Title: What the evidence shows
+
++++
+
+Content:
+Strong scientific evidence shows that being physically active can meaningfully improve your well-being and quality of life, especially in later life. A large review of 87 systematic reviews [14] and meta-analyses found that for adults — and particularly for older adults — regular physical activity leads to: better emotional well being, higher energy and vitality, improved daily functioning, better overall life satisfaction and greater mental health and mood. For older adults the evidence was strongest: Physical activity consistently improved both general well-being and health-related quality of life when compared with doing little or no activity. This means that moving more — in any way that works for you — can help you feel better day-to-day, stay more independent, and enjoy a higher quality of life throughout retirement.
+
+********************************************************************
+L02-S19-G048 | Lesson 2 Slide 19/27 | Global 48/271
+
+Title: What is cognitive function
+
++++
+
+Content: 
+Cognitive function is an umbrella term that includes several mental abilities: Attention: the ability to focus, sustain, and shift attention, Concentration: Holding attention on one task or thought, Memory: Short-term, long-term, and working memory, Executive function: Planning, decision making, problem-solving, flexibility, Processing speed: How quickly you can understand and respond. Cognitive function includes skills like memory, problem-solving, and attention. Focus and concentration are important parts of this — they help you stay sharp, learn new things, and complete daily tasks effectively. Focus and concentration are key aspects of attention—focus refers to directing your awareness toward a task, and concentration involves holding that focus over time.
+
+********************************************************************
+L02-S20-G049 | Lesson 2 Slide 20/27 | Global 49/271 
+
+Title: Did you know?
+
++++
+
+Content:
+Physical activity protects your brain [15]. A large systematic review of adults aged 60 and older found that physical activity is strongly linked to better cognitive function, even later in life. 26 out of 27 studies showed that being active helps maintain or improve memory, attention, and thinking skills. Several studies found a dose–response effect, meaning the more active people were, the greater the cognitive benefits. Physical activity may even help delay cognitive decline and protect against conditions like dementia. What this means for you: Even moderate activity, like walking, gardening, cycling, or group classes, can support a healthier, sharper brain as you age.
+
+********************************************************************
+L02-S21-G050 | Lesson 2 Slide 21/27 | Global 50/271
+
+Title: What the evidence shows 
+
++++
+
+Content: 
+Physical activity lowers dementia risk [16]. A major long-term study — the Framingham Heart Study — followed adults for up
+to 37 years to understand how physical activity over the adult life course affects dementia risk. Here's what they found:
+Staying active in midlife and later life makes a real difference. People who were the most active in midlife or later life had a 41% to 45% lower risk of developing dementia compared with those who were the least active. Midlife movement matters: Being active between ages 45–64 was especially protective — particularly for people engaging in moderate or heavy activity (walking briskly, cycling, swimming, active recreation). Late-life activity helps too: Even in your 70s and beyond, higher physical activity levels were still linked to lower risk of all-cause and Alzheimer’s dementia. Early adulthood didn’t show the same effect, but researchers note this may be because fewer dementia cases appeared during follow-up in that age group.
+
+********************************************************************
+L02-S22-G051 | Lesson 2 Slide 22/27 | Global 51/271
+
+Title: Main lesson takeaways 
+
++++
+
+Content:
+Here are the main takeaway points from the lesson: 1. Not only will regular exercise boost your energy levels, it also helps manage symptoms of depression and anxiety. 2. Exercise in all its forms will help reduce depression and anxiety symptoms, however the greatest impact can be seen with high intensity exercise. 3. Those who exercise regularly have increased quality of life, including things like increased self-esteem, social functioning, life satisfaction, and happiness.
+
+********************************************************************
+L02-S23-G052 | Lesson 2 Slide 23/27 | Global 52/271
+
+***DO NOT REFERENCE***
+
+Title: Quiz question
+
+********************************************************************
+L02-S24-G053 | Lesson 2 Slide 24/27 | Global 53/271
+
+***DO NOT REFERENCE***
+
+Title: Quiz question
+
+********************************************************************
+L02-S25-G054 | Lesson 2 Slide 25/27 | Global 54/271
+
+***DO NOT REFERENCE***
+
+Title: Quiz question
+
+********************************************************************
+L02-S26-G055 | Lesson 2 Slide 26/27 | Global 55/271
+
+***DO NOT REFERENCE***
+
+Title: References
+
+********************************************************************
+L02-S27-G056 | Lesson 2 Slide 27/27 | Global 56/271
+
+***DO NOT REFERENCE***
+
+Title: Lesson complete 
+
+==========================================================================================
+LESSON 3: Social Connections, Confidence and Enjoyment: Keys to an Active Life (27 slides)
+==========================================================================================
+L03-S01-G057 | Lesson 3 Slide 1/27 | Global 57/271
+
+Lesson Description: This lesson will help you explore how social connections, confidence, and enjoyment can work together to make physical activity a lasting and rewarding part of life after retirement.
+
+********************************************************************
+L03-S02-G058 | Lesson 3 Slide 2/27 | Global 58/271
+
+Title: What M-PAC says: Perceived Opportunity
+
++++
+
+Content:
+Perceived opportunity: According to the Multi-Process Action Control (M-PAC) framework, our perceived opportunities for social connection matter.Feeling welcomed, having companions, or joining groups can make it easier for intentions to turn into regular physical activity behaviour. These connections not only help us get started but also make staying active more enjoyable and sustainable [1].
+
+********************************************************************
+L03-S03-G059 | Lesson 3 Slide 3/27 | Global 59/271
+
+Title: What the evidence shows 
+
++++
+
+Content:
+Research shows that being active with others can reduce feelings of loneliness and strengthen social bonds. People who join group activities, exercise with friends, or connect through recreation often feel more included and part of their community. Large studies confirm these benefits worldwide [2,3], and in Canada, most people agree that sport, physical activity, and recreation reduce feelings of isolation and increase belonging [4].
+
+********************************************************************
+L03-S04-G060 | Lesson 3 Slide 4/27 | Global 60/271
+
+Title: Feeling connected matters
+
++++
+
+Content: 
+Retirement often brings changes in how we connect with others. After many years of seeing friends and colleagues through work or shared activities, it’s natural to notice you don’t see people as often as before. While this shift is common, finding new ways to stay connected can bring energy, purpose, and joy to this stage of life.
+
+********************************************************************
+L03-S05-G061 | Lesson 3 Slide 5/27 | Global 61/271
+
+Title: Did you know?
+
++++
+
+Content:
+61% of Canadians say sport, physical activity, and recreation helps reduce feelings of loneliness. 76% feel more welcomed and included through physical activity, sport and recreation activities [5]. Being active isn’t just good for your body — it’s a powerful way to stay connected, resilient, and thriving in retirement.
+
+********************************************************************
+L03-S06-G062 | Lesson 3 Slide 6/27 | Global 62/271
+
+Title: Make it social 
+
++++
+
+Content: 
+This week, try one activity with another person — it could be a walk with a friend, joining a class, or inviting a neighbour. Notice how it feels to move together.
+
+********************************************************************
+L03-S07-G063 | Lesson 3 Slide 7/27 | Global 63/271
+
+Title: Fitness instructor keeps seniors feeling young
+
++++
+
+Content:
+Video Overview: A retired fitness instructor shares how discovering group fitness after losing her spouse helped her regain strength, purpose, and connection. She highlights how staying active supports physical health, mental well-being, and social connection—especially for older adults facing loneliness.
+
+********************************************************************
+L03-S08-G064 | Lesson 3 Slide 8/27 | Global 64/271
+
+***DO NOT REFERENCE***
+
+Title: Reflection prompt
+
+********************************************************************
+L03-S09-G065 | Lesson 3 Slide 9/27 | Global 65/271
+
+Title: What M-PAC says: Perceived Capability
+
++++
+
+Content:
+Perceived capability: According to the M-PAC framework, our perceived capability matters. This is the confidence we have in our ability to be active. When we feel capable, our intentions are much more likely to turn into regular physical activity behaviour [1].
+
+********************************************************************
+L03-S10-G066 | Lesson 3 Slide 10/27 | Global 66/271
+
+Title: Confidence and physical activity
+
++++
+
+Content:
+People who feel more confident in their ability to be active usually end up doing more physical activity overall [6]. In research, this type of confidence is called self-efficacy [7]. Self-efficacy means your perceived capability to perform a behaviour. For physical activity, it’s about how confident you are that you can do the activity at hand [7]. In fact, higher levels of self-efficacy often distinguish someone who is active from someone who is not. It’s important not to confuse capability with motivation. We often say, “I can’t” when we really mean “I don’t want to.” But the opposite is also true — even if you want to be active, it’s difficult to follow through if you don’t feel confident that you can actually do it.
+
+********************************************************************
+L03-S11-G067 | Lesson 3 Slide 11/27 | Global 67/271
+
+Title: Did you know?
+
++++
+
+Content: 
+A recent study [8] found a small (but significant) effect of physical activity interventions on people’s self-efficacy for physical activity. This means that simply doing physical activity is enough to increase somebody’s self-confidence for it.
+
+********************************************************************
+L03-S12-G068 | Lesson 3 Slide 12/27 | Global 68/271
+
+***DO NOT REFERENCE***
+
+Title: Reflection prompt
+
+********************************************************************
+L03-S13-G069 | Lesson 3 Slide 13/27 | Global 69/271
+
+Title: Building your confidence
+
++++
+
+Content: 
+It’s normal to feel unsure about starting or re-starting physical activity in retirement. Confidence doesn’t appear overnight - but the good news is, it can be built over time.Research shows there are two main ways people increase their confidence (or self- efficacy) to be active [9]: Positive experiences: Meeting small, realistic goals (e.g. walking a little farther than last week). Feeling included and capable in an activity (e.g. joining a beginner-friendly class). Watching others succeed: Seeing friends, peers, or people “like you” being active. Exercising with someone else and noticing that they are enjoying it. What this means for you: Confidence grows by experiencing success — and success comes from starting small. You don’t need to be perfect, or an expert, on the first try. Choosing settings where you feel comfortable and surrounded by supportive people makes the process easier.
+
+********************************************************************
+L03-S14-G070 | Lesson 3 Slide 14/27 | Global 70/271
+
+Title: Susan's success cycle
+
++++
+
+Content:
+
+Susan, a retired nurse, wanted to be more active but wasn’t sure where to start. She decided to try her local gym (intention) and signed up for an introductory orientation session (trial). The trainer showed her how to use the equipment, and she completed the short session successfully (success). This small win boosted her confidence, making her feel more capable of trying the gym again the following week. When an experience leads to positive outcomes, the result can be a self-reinforcing “success cycle.” Each success builds confidence, which makes it more likely you’ll try again — and succeed again. 
+
+********************************************************************
+L03-S15-G071 | Lesson 3 Slide 15/27 | Global 71/271
+
+Title: The success cycle, visualized
+
++++
+
+Content:
+The success cycle, explained: when someone tries an activity and succeeds, it builds confidence, which makes them more likely to try again. Each successful experience reinforces confidence, creating a positive loop that supports continued physical activity over time.
+
+********************************************************************
+L03-S16-G072 | Lesson 3 Slide 16/27 | Global 72/271
+
+Title: How does affect relate to physical activity
+
++++
+
+Content:
+Our mood and emotions can have a big impact on whether or not we feel like being active: Daily moods can influence motivation. A sunny day might boost your desire to walk, while a stressful day might make the gym feel harder. The experience of physical activity itself also influences affect. If you expect PA to be enjoyable, you’re more likely to do it — and keep doing it [10, 11]. In short: the more fun and enjoyable PA feels, the more likely you are to stick with it.
+
+********************************************************************
+L03-S17-G073 | Lesson 3 Slide 17/27 | Global 73/271
+
+Title: Two ways to increase enjoyment 
+
++++
+
+Content:
+1: Make the activity itself better. 2: Pair activity with things you already enjoy [12]
+
+********************************************************************
+L03-S18-G074 | Lesson 3 Slide 18/27 | Global 74/271
+
+Title: Did you know?
+
++++
+
+Content:
+Enjoyment is one of the strongest predictors of who becomes — and stays — active. People who expect activity to feel good are more likely to form lasting exercise habits [10].
+
+********************************************************************
+L03-S19-G075 | Lesson 3 Slide 19/27 | Global 75/271
+
+Title: What M-PAC says: Affective Judgements
+
++++
+
+Content:
+Affective judgements: According to the M-PAC framework, our affective judgements — how pleasant or enjoyable we expect an activity to feel — matter. When we expect enjoyment, our intentions are much more likely to turn into regular physical activity behaviour [1].
+
+********************************************************************
+L03-S20-G076 | Lesson 3 Slide 20/27 | Global 76/271
+
+Title: What the evidence shows
+
++++
+
+Content: 
+Research consistently shows that people who enjoy physical activity are more likely to maintain it over time. This has been observed across all ages and life stages, including retirement. In fact, enjoyment often predicts activity better than health benefits or appearance goals [10,13]. The diagram shows a positive enjoyment loop: when people expect physical activity to be enjoyable, they are more likely to do it, leading to positive experiences. Those positive experiences increase enjoyment even further, reinforcing the cycle and making ongoing physical activity more likely over time.
+
+********************************************************************
+L03-S21-G077 | Lesson 3 Slide 21/27 | Global 77/271
+
+***DO NOT REFERENCE***
+
+Title: Reflection prompt
+
+********************************************************************
+L03-S22-G078 | Lesson 3 Slide 22/27 | Global 78/271 
+
+Title: Main lesson takeaways
+
++++
+
+Content: 
+Here are the main takeaway points from the lesson: 1. Perceived opportunity, perceived capability, and affective judgments all play a major role in turning intentions into regular physical activity. 2. Feeling socially connected makes activity more enjoyable and easier to sustain. 3. Confidence (self-efficacy) increases the likelihood that you’ll follow through on your intentions. 4. Feeling connected, feeling capable, and expecting enjoyment are key ingredients for building lasting physical activity habits.
+
+********************************************************************
+L03-S23-G079 | Lesson 3 Slide 23/27 | Global 79/271
+
+***DO NOT REFERENCE***
+
+Title: Quiz question
+
+********************************************************************
+L03-S24-G080 | Lesson 3 Slide 24/27 | Global 80/271
+
+***DO NOT REFERENCE***
+
+Title: Quiz question
+
+********************************************************************
+L03-S25-G081 | Lesson 3 Slide 25/27 
+
+***DO NOT REFERENCE***
+
+Title: Quiz question
+
+********************************************************************
+L03-S26-G082 | Lesson 3 Slide 26/27 | Global 82/271
+
+***DO NOT REFERENCE***
+
+Title: References
+
+********************************************************************
+L03-S27-G083 | Lesson 3 Slide 27/27 | Global 83/271
+
+***DO NOT REFERENCE***
+
+Title: Lesson complete 
+
+$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
+SECTION 2: How to be Active | M-PAC Regulation Processes Layer 
+$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
+
+========================================================================
+LESSON 4: Setting Goals and Planning Ahead for Active Living (22 slides)
+========================================================================
+L04-S01-G084 | Lesson 4 Slide 1/22 | Global 84/271
+
+Lesson Description: This lesson will help you set enjoyable, flexible goals and plan ahead so you can stay active, even when life gets in the way. 
+
+********************************************************************
+L04-S02-G085 | Lesson 4 Slide 2/22 | Global 85/271
+
+Title: What M-PAC says: Goals
+
++++
+
+Content: 
+Goals: The Multi-Process Action Control (M-PAC) framework explains that goals are part of the regulatory processes, which are the tactics that help people follow through on their intentions and turn them into regular behaviour [1,2]. Direction and focus
+goals guide your efforts by giving direction and focus. Clarity: They help turn “I want to be active” into a clear target behaviour. Action bridge: Goals act as the first step in bridging the gap between intention and action. M-PAC shows that setting meaningful, realistic goals helps turn good intentions into lasting activity.
+
+********************************************************************
+L04-S03-G086 | Lesson 4 Slide 3/22 | Global 86/271
+
+Title: What the evidence shows
+
++++
+
+Content: 
+Across many studies, researchers have found that goal setting is one of the most effective tactics for changing physical activity. People who set clear, flexible goals are more likely to follow through and stay consistent with their activity over time [3-6].
+
+********************************************************************
+L04-S04-G087 | Lesson 4 Slide 4/22 | Global 87/271
+
+Title: What are goals?
+
++++
+
+Content:
+A goal is “the object or aim of an action... to attain a specific standard of proficiency, usually within a specified time limit” [7]. Setting goals is more than just deciding what you want to do — it’s a proven way to guide your behaviour and make progress toward the things that matter most.
+
+********************************************************************
+L04-S05-G088 | Lesson 4 Slide 5/22 | Global 88/271
+
+Title: How do goals work?
+
++++
+
+Content: 
+Researchers have found that goals work in four important ways [8]: 1. Direct attention: they help you focus your energy on the chosen activity. 2. Boost motivation: they give you a clear reason to act. 3. Increase persistence: they encourage you to keep going, even when it is challenging. 4. Prompt action: they nudge you to make plans for success. For recent retirees, goals can be especially valuable. They provide structure and purpose in a time of life with potentially fewer external demands and more freedom to choose how you spend your time. For example: “I want to walk 20 minutes after lunch, three times a week, in my neighbourhood.” “I want to do 25 minutes of resistance training at the community centre gym on Tuesday and Thursday mornings.” In short: goals give purpose, focus, and the tools to turn intention into action.
+
+********************************************************************
+L04-S06-G089 | Lesson 4 Slide 6/22 | Global 89/271
+
+Title: What makes a goal effective?
+
++++
+
+Content:
+Research shows that some goals are more powerful than others in helping people stay motivated and follow through [7,8].
+Here are qualities that make goals more effective: Commitment matters: You’re more likely to succeed when the goal feels important, you believe you can do it (self-efficacy), and you expect to feel good when it’s achieved. Be specific and challenging: Goals that are clear and a little challenging (but realistic) work better than vague or easy ones. Positive framing: Focus on what you will do (“I will walk”) rather than what you want to avoid.Who sets the goal: Goals can be self-set, assigned by someone else, or set together with another person — all can work. Timeframe matters: Short-term goals can boost confidence, while long-term goals help sustain behaviour change. Task complexity: Goals help with both simple and complex activities, but complex ones may require extra steps or tactics.
+
+********************************************************************
+L04-S07-G090 | Lesson 4 Slide 7/22 | Global 90/271 
+
+Title: Making goals work for you
+
++++
+
+Content: 
+Now that you know what makes goals effective, here’s how to put it into practice [7,8]: Choose what matters to you: Goals are more powerful when they connect to your values, health, or things you enjoy. Keep them realistic: Challenge yourself, but make sure your goal is doable in your current routine. Think small and big: Set short-term steps (this week, this month) as well as long-term goals. Write it down: Putting your goal on paper or in your phone makes it more concrete. Tell someone: Sharing your goal with a friend or family member can keep you motivated and accountable. Stay flexible: Life happens, so be ready to adjust without feeling like you’ve failed.
+
+********************************************************************
+L04-S08-G091 | Lesson 4 Slide 8/22 | Global 91/271
+
+Title: What the evidence shows
+
++++
+
+Content:
+A recent study of active older adults called the MOVEAGE-ACT Study [9] found that: 1: They often set behavioural goals (e.g., walking regularly) rather than outcome goals (e.g., weight loss). 2: Goals that were enjoyable and personally meaningful were linked to stronger motivation. 3: Setting activity goals was connected to benefits for physical health, daily functioning, and mental well-being. In short: when retirees set enjoyable, meaningful activity goals, they are more likely to stay motivated and experience wide-ranging benefits.
+
+********************************************************************
+L04-S09-G092 | Lesson 4 Slide 9/22 | Global 92/271
+
+Title: See it in action
+
++++
+
+Content: 
+Want to hear directly from retirees about staying active and motivated? This short video shows how retirees use routines and goals to keep purpose and energy in daily life.
+
+********************************************************************
+L04-S10-G093 | Lesson 4 Slide 10/22 | Global 93/271 
+
+Title: Did you know?
+
++++ 
+
+Content:
+Research shows that 95% of adults already know about the health benefits of being active [10], and around 80% say they intend to be active [11,12]. Exercising more is even one of the most common New Year’s resolutions. But here’s the surprising part: only about half of those with positive intentions actually follow through [11,12]. This problem is known as the intention–behaviour gap — the space between wanting to be active and actually doing it.
+
+********************************************************************
+L04-S11-G094 | Lesson 4 Slide 11/22 | Global 94/271 
+
+Title: What M-PAC says: Intention-behaviour gap
+
++++
+
+Content:
+Intention-behaviour gap. M-PAC explains why good intentions often fail to become action — and points to the solution [1,2]. Intentions alone aren’t enough; people need tactics to follow through. Planning ahead is one of the key tactics that help bridge the gap. By deciding when, where, and how to act, planning makes it more likely that intentions will turn into real behaviour. In M-PAC, planning is the next step — it helps turn your goals into consistent behaviour.
+
+********************************************************************
+L04-S12-G095 | Lesson 4 Slide 12/22 | Global 95/271
+
+Title: Different ways to plan ahead
+
++++
+
+Content: 
+Researchers have found several approaches that can make goals easier to follow through: Action planning: Making a clear plan for what you’ll do when, where, and how [13]. Implementation intentions (if–then plans): Linking a situation to a response [14]. Coping planning: Thinking about barriers that might come up and deciding in advance how to handle them [15]. All of these approaches help make your goals stronger and more doable in real life.
+
+********************************************************************
+L04-S13-G096 | Lesson 4 Slide 13/22 | Global 96/271
+
+Title: What is action planning?
+
++++
+
+Content: 
+Action planning means going beyond saying “I want to be active” and creating a detailed plan for how you’ll do it. Researchers describe action planning as breaking down your intention into the when, where, and how of the behaviour [16,17]: When:
+The time of day or week (e.g., mornings, after lunch, evenings). Where: The location or context (e.g., park, gym, living room, neighbourhood). How: The specific sub-actions or steps you’ll take (e.g., type of exercises, equipment needed, routine to follow). Studies show that action planning is effective because it fosters translation from intention to action: the clearer the plan, the easier it is to follow through.
+
+********************************************************************
+L04-S14-G097 | Lesson 4 Slide 14/22 | Global 97/271
+
+Title: How to do action planning
+
++++
+
+Content:
+To make your goals stick, specify the details of your activity: For example: 1) On Monday, Wednesday, and Friday at 5pm (when), I will go for a 30-minute jog (how) around my neighbourhood (where). 2) I will do a 25-minute resistance routine at the community centre gym (where) on Tuesday and Thursday mornings (when), focusing on upper and lower body exercises (how). Important thing is to set behaviour goals (e.g. be active 3x/week) rather than outcome goals (e.g. lose weight)
+
+********************************************************************
+L04-S15-G098 | Lesson 4 Slide 15/22 | Global 98/271
+
+***DO NOT REFERENCE***
+
+Title: Goal setting practice
+
+********************************************************************
+L04-S16-G099 | Lesson 4 Slide 16/22 | Global 99/271 
+
+Title: Plan for enjoyment
+
++++
+
+Content:
+Physical activity is easier to stick with when it’s enjoyable. When you set your goals, also plan ways to make them fun: Choose routes you like (parks, waterfronts), Add music, podcasts, or audiobooks, exercise with friends or family, pick activities you genuinely look forward to (swimming, dancing, gardening), if you love golf or pickleball, make them part of your weekly plan. Enjoyment isn’t just a bonus — it’s part of your plan to stay active. Make sure to have fun along the way!
+
+********************************************************************
+L04-S17-G100 | Lesson 4 Slide 17/22 | Global 100/271
+
+Title: Main lesson takeaways
+
++++
+
+Content: 
+Here are the main takeaway points from the lesson: 1) Goal setting gives structure, purpose, and motivation in retirement. 2) The most effective goals are behavioural, enjoyable, and flexible. 3) Planning ahead helps bridge the gap between intentions and action. 4) Including enjoyment makes physical activity more rewarding and sustainable. 5) Setting goals now prepares you for monitoring and reviewing them in the next lesson.
+
+********************************************************************
+L04-S18-G101 | Lesson 4 Slide 18/22 | Global 101/271
+
+***DO NOT REFERENCE***
+
+Title: Quiz question
+
+********************************************************************
+L04-S19-G102 | Lesson 4 Slide 19/22 | Global 102/271
+
+***DO NOT REFERENCE***
+
+Title: Quiz question
+
+********************************************************************
+L04-S20-G103 | Lesson 4 Slide 20/22 | Global 103/271
+
+***DO NOT REFERENCE***
+
+Title: Quiz question
+
+********************************************************************
+L04-S21-G104 | Lesson 4 Slide 21/22 | Global 104/271
+
+***DO NOT REFERENCE***
+
+Title: References
+
+********************************************************************
+L04-S22-G105 | Lesson 4 Slide 22/22 | Global 105/271
+
+***DO NOT REFERENCE***
+
+Title: Lesson complete
+
+=============================================================================
+LESSON 5: Staying on Track: Monitoring Your Activity on Your Own  (25 slides)
+=============================================================================
+L05-S01-G106 | Lesson 5 Slide 1/25 | Global 106/271
+
+Lesson Description: In this lesson, you’ll learn how monitoring your activity can help you stay on track, supported, and active in retirement.
+
+********************************************************************
+L05-S02-G107 | Lesson 5 Slide 2/25 | Global 107/271
+
+Title: What M-PAC says: Self-monitoring 
+
++++
+
+Content:
+Self-monitoring. The Multi-Process Action Control (M-PAC) framework explains that self-monitoring is part of the regulatory processes, which are the tactics that help people follow through on their intentions and turn them into regular behaviour [1,2]. It keeps your goals visible so they don’t get forgotten. It provides feedback about your progress and helps you notice when you’re drifting off track. In short: self-monitoring is like a personal compass, guiding you to keep moving in the right direction.
+
+********************************************************************
+L05-S03-G108 | Lesson 5 Slide 3/25 | Global 108/271
+
+Title: What the evidence shows 
+
++++
+
+Content:
+Research consistently shows that self-monitoring is one of the most established markers of success in physical activity interventions, particularly when combined with other regulation tactics such as goal-setting or action planning [3,4]. A review of 122 studies found interventions with self-monitoring produced stronger and longer-lasting increases in activity [4]. Self-monitoring is effective across a wide range of activities — from walking to strength training, mobility exercises, swimming, gardening, and sports. Research shows that adults who use tools such as logs, wearable trackers, or phone apps tend to be more consistent and motivated in their activity [5]. Bottom line: self-monitoring doesn't just help you start being active, it helps you keep going.
+
+********************************************************************
+L05-S04-G109 | Lesson 5 Slide 4/25 | Global 109/271
+
+Title: What is self-monitoring 
+
++++
+
+Content:
+Self-monitoring means keeping track of your own behaviour so that you can reflect, learn, and make changes when needed. It’s the ongoing process of observing and evaluating one’s thoughts, feelings, and behaviours. It can be dynamic (checking in as things are happening) or retrospective (looking back on what you did) [6]. Self-monitoring can take two main forms: internal and external. Internal self-monitoring involves paying attention to how you feel and noticing patterns in your body or mood. For example, you might notice changes in your energy levels or realize that you feel better on days when you do yoga or go for a walk. External self-monitoring involves recording what you do, when you do it, and for how long. This can be done using a device like a wearable tracker, an app on your phone, or a written record such as a journal or calendar. The simple act of recording whether through awareness or a tool makes progress more visible and provides valuable feedback for future choices.
+
+********************************************************************
+L05-S05-G110 | Lesson 5 Slide 5/25 | Global 110/271
+
+Title: Benefits of self-monitoring for recent retirees
+
++++
+
+Content: 
+Self-monitoring can be especially valuable during retirement, when daily routines may be less structured than during working life [7,8]. Self-monitoring increases awareness of your daily activity levels. It provides a sense of progress and achievement, helping you see how far you’ve come. It encourages consistency in routines like walking, stretching, hiking, or social sports such as pickleball. It creates structure in otherwise unstructured time, helping physical activity become part of your day. It makes activity visible, which strengthens motivation and supports follow-through.
+
+********************************************************************
+L05-S06-G111 | Lesson 5 Slide 6/25 | Global 111/271
+
+Title: Did you know?
+
++++
+
+Content:
+Many retirees find that tracking their activity gives structure to their day — like a daily anchor that helps them feel purposeful, energized, and motivated [9].
+
+********************************************************************
+L05-S07-G112 | Lesson 5 Slide 7/25 | Global 112/271 
+
+Title: The thermostat analogy 
+
++++
+
+Content: 
+Researchers believe that physical activity behaviour can be regulated through a feedback loop: you set a goal, monitor your current state, and adjust your actions if there's a gap [10]. A thermostat is often used as an analogy to explain this idea: the temperature you set on a thermostat is like your behavioural goal (e.g., “walk three times a week” or “do strength exercises twice a week”). When the thermostat senses the temperature is too hot or too cold, it adjusts to bring things back to the target. In the same way, when you notice you are not meeting your activity goals, self- monitoring helps you make changes — trying a different activity, adjusting your plan, or resetting your goal. Without monitoring, you may not even notice that you are drifting away from your plan. Monitoring gives you the chance to catch small slips early and get back on track.
+
+********************************************************************
+L05-S08-G113 | Lesson 5 Slide 8/25 | Global 113/271
+
+Title: Tools for self-monitoring
+
++++
+
+Content:
+There is no one “best” way to self-monitor. The right tool is the one that feels simple and natural for you. High tech: Apple Watch, Fitbit, Garmin, or other wearables like Phone health apps (e.g., Apple Health, Google Fit). Low tech: Simple pedometer, Marking activity on fridge or wall calendar. No tech: Exercise journal for strength, yoga, or hiking, Logbook for weekly pickleball matches, hikes, or mobility sessions. Tip: choose a tool that matches the activities you enjoy most, and one you’ll actually use regularly
+
+********************************************************************
+L05-S09-G114 | Lesson 5 Slide 9/25 | Global 114/271
+
+Title: How to self-monitor
+
++++
+
+Content: 
+Here’s a simple step-by-step way to start: 1) Decide what to track: steps, minutes, or sessions of activity. 2) Choose a method: Apple Watch, Fitbit, pedometer, calendar, or journal. 3) Record and check your progress regularly: note your activity and look back at your entries to see how you’re doing.
+
+********************************************************************
+L05-S10-G115 | Lesson 5 Slide 10/25 | Global 115/271
+
+Title: Step tracking in Pathverse
+
++++
+
+Content: Syncing your health data to the pathverse app to monitor your step count.
+
+********************************************************************
+L05-S11-G116 | Lesson 5 Slide 11/25 | Global 116/271
+
+Title: Tips for success
+
++++
+
+Content:
+Keep your monitoring tool visible — e.g., a fridge calendar, wall chart, or bedside notebook. Use reminders from devices (like watch or phone notifications) to prompt you at the right time. Link recording to something you already do (e.g., log your activity before dinner). Celebrate small wins (e.g., circle your best day of the week). Don’t chase perfection — consistency matters more than flawless tracking. If one method feels like a burden, try another.
+
+********************************************************************
+L05-S12-G117 | Lesson 5 Slide 12/25 | Global 117/271
+
+Title: Did you know?
+
++++
+
+Content: Research shows that objective tools like wearables and apps often lead to better results than pen-and-paper logs, because they track activity automatically and reduce the burden on you [12]. The most important thing is to find a tool you feel comfortable using — whether that’s a smartwatch, a phone app, or a simple written record.
+
+********************************************************************
+L05-S13-G118 | Lesson 5 Slide 13/25 | Global 118/271
+
+Title: Check-in and reflect 
+
++++
+
+Content:
+If your plan isn’t working, don’t just repeat it — adjust it. Self-monitoring isn’t about perfection, it’s about learning from your experience and staying flexible. Set aside a regular “check-in day” (e.g., once a week) to step back, review your activity, and decide if your goals are realistic for the coming week. Focus on what you enjoy and will sustain long term: pickleball, hiking, gardening, mobility or balance routines, or strength training. Adapt to life changes: rainy week? Switch hiking for indoor stretching or yoga. Busy week? Aim for shorter but more frequent sessions. Learn from slips: missing a few days doesn’t mean failure — it’s feedback. Use it to adjust your plan, not abandon it. Action: Write down what you’ll track, how you’ll do it, and when you’ll review it. Think about what worked last week, what didn’t, and how you’ll adjust moving forward.
+
+********************************************************************
+L05-S14-G119 | Lesson 5 Slide 14/25 | Global 119/271
+
+Title: What M-PAC says: Social Monitoring 
+
++++
+
+Content:
+Social monitoring: In M-PAC, social monitoring is part of the regulatory processes – tactics that help people follow through on their intentions [1,2]. It involves the inclusion of others in the enactment of behaviour, such as exercising with a friend, joining a class, or checking in with a group. This makes your goals more visible and accountable in your social world. Support from friends, partners, or peers can help you adjust when you slip, and celebrate when you succeed. Social monitoring strengthens follow-through because you're bot carrying the journey alone. There are others to check in with, celebrate progress, and help you stay on track. That makes all the difference!
+
+********************************************************************
+L05-S15-G120 | Lesson 5 Slide 15/25 | Global 120/271 
+
+Title: What the evidence shows 
+
++++
+
+Content:
+Research shows that social monitoring and accountability enhance the effects of self-monitoring: Social support consistently predicts higher physical activity across adulthood [8]. Group-based interventions for older adults are especially effective when participants share progress or check in with each other [7,12]. Social ties provide motivation, structure, and encouragement, reducing the chance of dropping out. Bottom line: involving others in your monitoring more enjoyable and easier to maintain, especially when combined with self-monitoring.
+
+********************************************************************
+L05-S16-G121 | Lesson 5 Slide 16/25 | Global 121/271
+
+Title: What is social monitoring 
+
++++
+
+Content:
+Social monitoring means inviting other people to play a role in observing, encouraging, or joining your activity progress. It adds accountability by making your activity visible to others. It fosters commitment, because you’re not just answering to yourself, but also to a partner, group, or community. It involves tactics that use social variables in behavioural regulation — for example, joining a walking group or logging progress in a class [12]. Examples for recent retirees include: A walking partner who asks, “Did you get out today?” A pickleball group that keeps track of weekly games. A family member who checks your step counts when you share them. A fitness class instructor who records attendance. Just like self-monitoring, social monitoring provides feedback, but now it comes from your connections with others who help you stay on track.
+
+********************************************************************
+L05-S17-G122 | Lesson 5 Slide 17/25 | Global 122/271
+
+Title: Benefits for recent retirees
+
++++
+
+Content:
+Social monitoring can [7,8,12]: Add accountability (others notice if you skip). Provide encouragement on hard days. Make activity more social and fun. Give structure to your week (e.g. regular group sessions). Reinforce a sense of belonging and togetherness through shared activity. 
+
+********************************************************************
+L05-S18-G123 | Lesson 5 Slide 18/25 | Global 123/271
+
+Title: Did you know?
+
++++
+
+Content:
+Research shows that people are more motivated to be active when they feel a sense of belonging and togetherness with others [13]. Consider: Joining a walking club, fitness class, or pickleball group can provide that connection. Being part of a group makes activity more enjoyable and meaningful — because you’re doing it with others, not just on your own.
+
+********************************************************************
+L05-S19-G124 | Lesson 5 Slide 19/25 | Global 124/271
+
+Title: The garden club analogy
+
++++
+
+Content:
+Social monitoring is like being a part of a gardening club. Everyone can see how each garden is coming along. Members share encouragement, tips, and notice if someone is struggling. Progress feels more real when it’s shared — and being part of the group keeps you tending your own garden. In the same way, when you let others see your activity progress, you get feedback, support, and motivation to keep moving.
+
+********************************************************************
+L05-S20-G125 | Lesson 5 Slide 20/25 | Global 125/271
+
+Title: Main lesson takeaways
+
++++
+
+Content: 
+Here are the main takeaway points from the lesson: 1) Research shows that both self-monitoring and social monitoring are powerful tools for staying active. 2) On their own, each has benefits — self-monitoring keeps you accountable to yourself, while social monitoring adds encouragement and belonging. 3) But relying only on others is often not enough to sustain activity. 4) The most effective approach is to combine the two: track your own progress and share it with others. Together, self- and social monitoring create the strongest foundation for building and maintaining an active lifestyle in retirement.
+
+********************************************************************
+L05-S21-G126 | Lesson 5 Slide 21/25 | Global 126/271
+
+***DO NOT REFERENCE***
+
+Title: Quiz question 
+
+********************************************************************
+L05-S22-G127 | Lesson 5 Slide 22/25 | Global 127/271
+
+***DO NOT REFERENCE***
+
+Title: Quiz question 
+
+********************************************************************
+L05-S23-G128 | Lesson 5 Slide 23/25 | Global 128/271
+
+***DO NOT REFERENCE***
+
+Title: Quiz question 
+
+********************************************************************
+L05-S24-G129 | Lesson 5 Slide 24/25 | Global 129/271
+
+***DO NOT REFERENCE***
+
+Title: References
+
+********************************************************************
+L05-S25-G130 | Lesson 5 Slide 25/25 | Global 130/271
+
+***DO NOT REFERENCE***
+
+Title: Lesson complete
+
+====================================================================
+LESSON 6: How to Keep Moving When You Don't Feel Like It (21 slides)
+====================================================================
+L06-S01-G131 | Lesson 6 Slide 1/21 | Global 131/271
+
+Lesson Description: This lesson will provide you with practical tools and tactics to stay active especially for the times when you don’t feel like it.
+
+********************************************************************
+L06-S02-G132 | Lesson 6 Slide 2/21 | Global 132/271
+
+Title: What M-PAC says: Reactive regulation 
+
++++
+
+Content:
+The Multi-Process Action Control (M-PAC) framework explains that reactive regulation is a part of the regulatory processes, which are the tactics that help people follow through on their intentions and turn them into regular behaviour [1,2]. Reactive regulation means adapting to circumstances after they arise — for example, adjusting when fatigue, stress, or unexpected events interfere with your plans. In other words, making a plan is important but learning how to adjust in the moment is just as important for turning good intentions into action!
+
+********************************************************************
+L06-S03-G133 | Lesson 6 Slide 3/21 | Global 133/271
+
+Title: What the evidence shows
+
++++
+
+Content:
+One of the most common ways people use reactive regulation is through emotion regulation tactics that help manage feelings in the moment [3]. A recent review of 30 studies found that programs teaching these tactics led to small but meaningful increases in physical activity [4]. In simple terms, people who learned how to manage emotions like stress, low mood, or tiredness were more likely to stay active compared to those who didn’t get these supports. For example, people who learned how to reframe the thought “I’m too tired” into “I’ll just start with 10 minutes” were more likely to keep moving.The review also showed that the biggest benefits often came from shorter, smaller studies with self-reported activity — so while results look promising, more large- scale trials are still needed. 
+
+********************************************************************
+L06-S04-G134 | Lesson 6 Slide 4/21 | Global 134/271
+
+Title: What is affect?
+
++++
+
+Content:
+Affect is a word researchers use to describe feeling states such as emotions and mood [11], but most agree that our moods can be described as a mix of: Positive or negative feelings, and Low or high levels of stimulation (energy).
+
+********************************************************************
+L06-S05-G135 | Lesson 6 Slide 5/21 | Global 135/271
+
+Title: Why does this matter for you?
+
++++
+
+Content:
+Scientists show affect this way because it helps explain how our feelings can influence our choices — including whether or not we feel like being active.When you’re feeling positive and energized (for example, excited, upbeat, or motivated), physical activity tends to feel more attractive and easier to start. You’re more likely to think, “Yeah, a walk sounds good right now.” When you’re feeling negative or low-energy (for example, bored, tired, stressed, or flat), the same activity can feel much harder to begin, even if you know it’s good for you. You might think, “I know I should move, but I just don’t feel like it.”. Our feelings and our energy levels matter for physical activity. By noticing your moods, and finding ways to make activity feel more enjoyable, you can make it easier to stay active.
+
+********************************************************************
+L06-S06-G136 | Lesson 6 Slide 6/21 | Global 136/271
+
+Title: Did you know?
+
++++
+
+Content: 
+Did you know that how you feel during activity is one of the best predictors of whether you will want to do it again? Research shows that when people enjoy their activity — or can manage uncomfortable feelings in the moment — they are more likely to repeat it in the future [6,7].
+
+********************************************************************
+L06-S07-G137 | Lesson 6 Slide 7/21 | Global 137/271
+
+Title: What is emotional regulation?
+
++++
+
+Content:
+Emotion regulation is broadly defined as any effort to modify an emotional experience [3]. In the context of physical activity, emotional regulation tactics help you work with your feelings so emotions like tiredness, stress, or low mood don’t prevent you from being active.
+Researchers describe three main kinds of emotional regulation tactics: Attention deployment: Shifting focus (e.g., noticing the scenery on a cycle ride, listening to music, or distracting yourself from discomfort). Cognitive change: Reframing how you think (e.g., turning “this feels hard” into “this is helping me get stronger”). Response modulation: Managing your reaction (e.g., calming yourself with slow breathing, stretching, or gentle self-talk). In physical activity research, these emotional regulation tactics are especially useful when challenges come up in the moment. They help you stay connected to your intentions and carry out activity you planned [8,9].
+
+********************************************************************
+L06-S08-G138 | Lesson 6 Slide 8/21 | Global 138/271
+
+Title: Practical physical activity examples
+
++++
+
+Content: 
+Here’s how emotion regulation tactics can help with everyday barriers: 1) Feeling fatigued (Cognitive change); Aerobic: Instead of skipping your cycle, reframe: “A short ride is still good for me”, Strength: Tell yourself: “Even a light set with resistance bands will help me stay strong”, Flexibility: Think: “Ten minutes of stretching will ease tension in my body” 2) Feeling stressed (Response modulation); Aerobic: Use calming music during a brisk walk to shift your mood, Strength: Practice slow breathing between light weight sets, Flexibility: Try yoga or tai chi with a focus on calm breathing. 3) “I don’t feel like it” (Attention deployment); Aerobic: Put on energizing music while dancing — focus on the rhythm, Strength: Play your favourite playlist during weights and focus on the beat, Flexibility: Notice the calming background (music, nature sounds) as you stretch. These tactics — cognitive change, response modulation, and attention deployment — can help you manage emotions in the moment and keep activity part of your daily life.
+
+********************************************************************
+L06-S09-G139 | Lesson 6 Slide 9/21 | Global 139/271
+
+Title: The traffic light analogy 
+
++++
+
+Content: 
+Think of your emotions like a traffic light; Stop: Pause and notice what you’re feeling (fatigue, stress, “I don’t feel like it.”), Reflect: Choose how to respond. Which tactic will help — reframing your thought, calming your body, or shifting your focus?, Go: Put the tactic into action and move forward with your activity.
+
+********************************************************************
+L06-S10-G140 | Lesson 6 Slide 10/21 | Global 140/271
+
+Title: Tools for emotion regulation 
+
++++
+
+Content: 
+Here are some practical tactics you can try the next time emotions get in the way of your activity; Breathing exercises: Slow, deep breathing helps calm the body and reduce stress (response modulation) [10]. Reframing thoughts: Change “This feels hard” into “This is helping me stay healthy and strong” (cognitive change) [3]. Distraction: Use music, podcasts, or an audiobook to shift your focus (attention deployment) [8]. Mindfulness: Notice the feeling without judgment and gently return your attention to the activity (acceptance-based ER) [9]. Gentle self-talk: Remind yourself: “Even a little activity is better than none” (cognitive change) [11].
+
+********************************************************************
+L06-S11-G141 | Lesson 6 Slide 11/21 | Global 141/271
+
+***DO NOT REFERENCE***
+
+Title: Reflection activity
+
+********************************************************************
+L06-S12-G142 | Lesson 6 Slide 12/21 | Global 142/271
+
+Title: Did you know? 
+
++++ 
+
+Content: 
+Your mood during activity is one of the best predictors of whether you’ll keep doing it long-term? Research shows that when people enjoy their activity — or can manage negative feelings in the moment — they are more likely to stick with it [6,7]. This means learning emotion regulation tactics isn’t just about “getting through today” — it’s about increasing your enjoyment while being active, so you’re more likely to do it again.
+
+********************************************************************
+L06-S13-G143 | Lesson 6 Slide 13/21 | Global 143/271
+
+Title: Making sense of the diagram 
+
++++ 
+
+Content: 
+Diagram purpose: This model explains that how you feel depends on both how positive or negative your mood is and how much energy you have. High-energy positive feelings make activity feel easier to start, while low-energy or negative states make it feel harder, even if the activity itself hasn’t changed. It shows why motivation fluctuates and why managing mood and energy can help you stay active.
+
+********************************************************************
+L06-S14-G144 | Lesson 6 Slide 14/21 | Global 144/271
+
+***DO NOT REFERENCE***
+
+Title: Reflection prompt
+
+********************************************************************
+L06-S15-G145 | Lesson 6 Slide 15/21 | Global 145/271
+
+Title: Why emotion regulation matters for staying active
+
++++
+
+Content:
+Even with the best intentions, daily life often gets in the way. Retirement can bring new routines, shifting energy levels, or unexpected health changes. Feelings like stress, fatigue, or low mood can quickly turn into reasons not to exercise. This is where emotion regulation tactics become so important. They give you tools to handle those feelings so you can act on your plans instead of postponing or abandoning them [8,9]. For example: Before an aerobic activity like dancing, stress might make you hesitate. Focusing on the fun social side can make it easier to join in. Before a strength activity like lifting light weights, fatigue might discourage you. Reminding yourself that “even a few sets will help my body stay strong” can boost your willingness to start. By helping you stay flexible and resilient, emotional regulation tactics make it more likely you’ll keep translating good intentions into action.
+
+********************************************************************
+L06-S16-G146 | Lesson 6 Slide 16/21 | Global 146/271
+
+Title: Main lesson takeaways
+
++++
+
+Content:
+Here are the main takeaway points from the lesson: You learned about Reactive Regulation — how to handle emotions and moods that show up when you’re trying to be active. 1) Emotional Regulation means managing emotions in the moment so they don’t stop you from being active. 2) It involves three main tactics: attention deployment (shift focus), cognitive change (reframe thoughts), and response modulation (calm your body). 3) Using emotional regulation can increase enjoyment and make it easier to repeat physical activity.
+
+********************************************************************
+L06-S17-G147 | Lesson 6 Slide 17/21 | Global 147/271
+
+***DO NOT REFERENCE***
+
+Title: Quiz question
+
+********************************************************************
+L06-S18-G148 | Lesson 6 Slide 18/21 | Global 148/271
+
+***DO NOT REFERENCE***
+
+Title: Quiz question
+
+********************************************************************
+L06-S19-G149 | Lesson 6 Slide 19/21 | Global 149/271
+
+***DO NOT REFERENCE***
+
+Title: Quiz question
+
+********************************************************************
+L06-S20-G150 | Lesson 6 Slide 20/21 | Global 150/271
+
+***DO NOT REFERENCE***
+
+Title: References
+
+********************************************************************
+L06-S21-G151 | Lesson 6 Slide 21/21 | Global 151/271
+
+***DO NOT REFERENCE*** 
+
+Title: Lesson complete
+
+$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
+SECTION 3: Sustain your changes | M-PAC Regulation Reflexive Layer 
+$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
+
+============================================================
+LESSON 7: The Habit Recipe: Cue, Routine, Repeat (32 slides)
+============================================================
+L07-S01-G152 | Lesson 7 Slide 1/32 | Global 152/271
+
+Lesson Description: This lesson will provide you with practical tools and tactics to help you build habits that support physical activity.
+
+********************************************************************
+L07-S02-G153 | Lesson 7 Slide 2/32 | Global 153/271
+
+Title: What M-PAC says: Habits
+
++++
+
+Content:
+The Multi-Process Action Control (M-PAC) framework explains that some behaviours can feel almost automatic — like being on autopilot.
+Researchers call these reflexive processes. They develop when you repeat an activity over time, usually in response to the same environmental cues (like time of day, place, or objects around you) [1,2]. A habit is a behaviour that happens without much thought — triggered by your environment. For example, if you always go for a walk after breakfast, over time the act of finishing breakfast becomes a cue that automatically gets you moving. In other words: Intentions, goal setting, and behavioural regulation help you get started but habits help you keep going.
+
+********************************************************************
+L07-S03-G154 | Lesson 7 Slide 3/32 | Global 154/271
+
+Title: What the evidence shows
+
++++
+
+Content:
+Research shows that habits are one of the strongest predictors of whether people keep up physical activity in the long-term [3].
+In one study, 111 new gym members were tracked over 12 weeks. The researchers found that it took about 6 weeks of being active at least 4 times per week before exercise started to feel like a true habit [4]. The strongest factors that helped people build habits were: Consistency
+Doing activity regularly in the same context, Simplicity: Choosing activities that aren’t too complicated, Supportive environment: Setting up spaces or cues that make activity easy and Positive feelings: Enjoying the activity and feeling good about it
+
+********************************************************************
+L07-S04-G155 | Lesson 7 Slide 4/32 | Global 155/271
+
+Title: What are habits?
+
++++
+
+Content:
+When most people think about habits, they imagine something they “have” — like “I have a habit of walking every morning.”
+But researchers explain habits differently. A habit is not the behaviour itself. It’s the automatic process that connects a cue in your environment to a behavioural response. Habits are cue-response associations. When you encounter the cue (like brushing your teeth or finishing breakfast), your brain automatically generates an impulse to act. This process requires much less mental effort than making a fresh decision every time. Key point: Habits don’t replace behaviour – they trigger behaviour.
+
+********************************************************************
+L07-S05-G156 | Lesson 7 Slide 5/32 | Global 156/271
+
+Title: Instigation vs execution
+
++++
+
+Content:
+Physical activity is a complex behaviour, which makes it hard to run on autopilot. Instead, researchers highlight two phases: instigation, where you decide to start the activity (often triggered by cues and habits), and execution, where you carry out the activity and still need effort, planning, and self-regulation. So, habits don’t do the whole job — but they remove the biggest barrier by getting you moving. 
+
+********************************************************************
+L07-S06-G157 | Lesson 7 Slide 6/32 | Global 157/271
+
+Title: The "behaviour = habit' trap
+
++++
+
+Content:
+The “behaviour = habit” trap. It’s easy to fall into the trap of thinking the behaviour is the habit. “Walking every day is my habit.”, “I broke my habit of snacking at night.” But this view can be misleading. Habits are not behaviours. They are the processes that bias you toward behaviours when the cue appears.
+
+********************************************************************
+L07-S07-G158 | Lesson 7 Slide 7/32 | Global 158/271
+
+Title: Why this matters 
+
++++
+
+Content:
+If we confuse habit with behaviour, it looks like someone has “broken” a habit when they stop a behaviour. In reality, the habit association may still exist — and can be re-triggered when old cues reappear. Example: Contestants on The Biggest Loser adopt new exercise and diet routines at bootcamps. It looks like their old habits are “gone.” But when they return home, old cues (like the TV and snacks) are still there, and these cues can automatically trigger old behaviours again. Key points: Habits are inputs into routines, not the whole routine. You can have a habit without always acting on it, which explains why relapse happens when old cues resurface
+
+********************************************************************
+L07-S08-G159 | Lesson 7 Slide 8/32 | Global 159/271
+
+Title: Why habits are important
+
++++
+
+Content:
+At first, changing health behaviours like physical activity takes a lot of mental effort. You need to make conscious decisions, plan ahead, and motivate yourself. This stage can feel tiring because it relies on your executive resources — the same mental “muscle” you use for problem-solving or making decisions [3,6]. But as habits form, behaviour initiation becomes less deliberative and more automatic in response to contextual cues [7]. Instead of weighing up choices every time, the cue itself (like finishing breakfast) triggers the behaviour (like going for a walk). This makes action feel easier, smoother, and less reliant on willpower.
+
+********************************************************************
+L07-S09-G160 | Lesson 7 Slide 9/32 | Global 160/271
+
+Title: Why this matters
+
++++
+
+Content: 
+Habits free up mental energy, so staying active requires less conscious effort. Once established, habits are persistent — they tend to “stick” even when motivation is low. Habits are context-dependent: the stronger the link between cue and behaviour, and the more often the cue appears, the more reliable the behaviour becomes [9]. In short, healthy habits are powerful because they: help turn one-off choices into routines, protect against dips in motivation and support the long-term maintenance of behaviour change. This is why researchers believe building strong physical activity habits is one of the best ways to keep people active in retirement and beyond [7,8].
+
+********************************************************************
+L07-S10-G161 | Lesson 7 Slide 10/32 | Global 161/271
+
+Title: The recipe for habit
+
++++
+
+Content:
+
+So, how do habits actually form? Researchers describe a simple “recipe” for habit: Cue + Routine + Repetition = Habit. Cue is a trigger in your environment that reminds you to act (e.g., finishing breakfast, the 6pm news). Routine: the activity itself (e.g., a short walk, stretching, lifting resistance bands). Repetition: doing the same activity, in the same context, again and again until it feels automatic.
+
+********************************************************************
+L07-S11-G162 | Lesson 7 Slide 11/32 | Global 162/271
+
+Title: Cues in action
+
++++
+
+Content:
+Over time, your brain links the cue with the routine — so when the cue shows up, the behaviour follows naturally. Examples of habit “recipes”: Aerobic: After breakfast (cue) → put on shoes and walk around the block (routine) → repeat daily. Strength: After drinking morning tea/coffee (cue) → do 2 sets with resistance bands (routine) → repeat every morning. Flexibility: When the evening news starts (cue) → stretch during the first 5 minutes (routine) → repeat daily. Balance: After brushing teeth at night (cue) → stand on one leg for 30 seconds (routine) → repeat nightly. The key isn’t doing a lot at once — it’s repeating small actions in the same context until they stick. Using an app to log new cue–routine pairing can helps reinforce the link.
+
+********************************************************************
+L07-S12-G163 | Lesson 7 Slide 12/32 | Global 163/271
+
+Title: Did you know?
+
++++
+
+Content:
+Research shows that instigation habits automatically starting an activity—are much stronger predictors of physical activity than execution habits, which focus on how the activity unfolds once it’s begun [10,11]. Many people intend to be active but stall at the starting line. Instigation habits lower that barrier by prompting action when the cue appears, without needing extra motivation. Think of them like a car’s starter motor: they don’t drive the whole journey, but they reliably get the engine running.
+
+********************************************************************
+L07-S13-G164 | Lesson 7 Slide 13/32 | Global 164/271
+
+Title: What makes a good cue?
+
++++
+
+Content: 
+Not all cues are created equal. Some triggers are stronger and more reliable than others. Strong cues are: Specific – linked to a clear behaviour (e.g., “after I brush my teeth, I stretch”), Consistent – happen regularly in your day (e.g., making your bed every morning) and Context-based – tied to your environment or routine (e.g., shoes by the door). Weaker cues are: Vague – “I’ll exercise when I feel like it.”, Irregular – tied to unpredictable events (e.g., “only when the weather is good”) and Motivation-based – relying on how you feel in the moment. Example: Strong cue = “After I finish my coffee, I’ll do 10 squats", Weak cue = “I’ll do squats when I have time.”
+
+********************************************************************
+L07-S14-G165 | Lesson 7 Slide 14/32 | Global 165/271
+
+Title: Is it true it takes 66 days to form a habit?
+
++++
+
+Content: 
+Short answer: there’s no single magic number. The “66 days” figure comes from one study, but the real time varies a lot from person to person and from behaviour to behaviour [3]. What the study found: 96 volunteers chose a daily behaviour (like drinking water with lunch or walking after breakfast) and repeated it in the same context for 12 weeks. They tracked whether they did it and how automatic it felt, using the Self- Report Habit Index. Habit strength increased quickly at first, then levelled off — following what scientists call an “asymptotic curve.” Reaching a strong level of automaticity took anywhere from 18 days to 254 days depending on the person and behaviour. Missing one day didn’t disrupt the process. From graph: Habit strength increasing over time. Early on, progress is rapid, with a steep climb where each repetition leads to noticeable gains. As time goes on, the curve flattens, meaning progress slows but continues steadily until habit strength reaches a stable plateau. Building a habit is like climbing a hill: it’s steep at the start with big improvements, then it flattens near the top. Later, the steps feel smaller, but you’re still moving forward until the habit feels natural and automatic.
+
+********************************************************************
+L07-S15-G166 | Lesson 7 Slide 15/32 | Global 166/271
+
+Title: What this means for you
+
++++
+
+Content:
+
+Research shows that while 66 days is often cited as the average time it takes to form a habit, the actual timeline can vary widely [3]. Some habits develop much more quickly, while others may take considerably longer. Simple behaviours, such as drinking a glass of water, tend to form faster than more complex routines, like adopting a new workout program. What truly matters is having a stable cue and repeating the behaviour consistently. Instead of focusing on a specific number of days, it’s more helpful to focus on consistency. Over time, habits gradually strengthen until they feel natural and automatic.
+
+********************************************************************
+L07-S16-G167 | Lesson 7 Slide 16/32 | Global 167/271
+
+***DO NOT REFERENCE***
+
+Title: Reflection prompt
+
+********************************************************************
+L07-S17-G168 | Lesson 7 Slide 17/32 | Global 168/271
+
+Title: Common habit pitfalls (and how to best handle them)
+
++++
+
+Content:
+Even the best habit recipes don’t always go perfectly. Here are some common challenges — and ways to manage them: 1) Missing a day:
+“I forgot to stretch after the news last night.” Don’t panic. Missing once does not erase your habit. Just restart at the next opportunity. 2) Choosing a routine that’s too big: “I planned a 30-minute workout but it felt overwhelming.” Start smaller. A 5-minute walk or 1 set with resistance bands is easier to repeat — and still builds the habit. 3) Weak or irregular cues: “I said I’d exercise when I felt motivated, but that rarely happens.” Use a strong, consistent cue like a daily meal or brushing teeth. 4) Losing interest: “My walk feels boring now.” Keep the cue the same, but change the routine: walk a different route, use music, or try a short dance instead.
+
+********************************************************************
+L07-S18-G169 | Lesson 7 Slide 18/32 | Global 169/271
+
+Title: Did you know?
+
++++
+
+Content:
+Habits can keep you active even when your motivation runs low — but they can also be fragile if disrupted for long periods. Once established, habits often persist automatically when the cue appears [5]. However, they are also highly context-dependent. Changes in your routine or environment — such as travelling, illness, or moving to a new home — can remove the cues that supported your habit, making it harder to maintain the behaviour [7].
+
+********************************************************************
+L07-S19-G170 | Lesson 7 Slide 19/32 | Global 170/271
+
+Title: What this means for you
+
++++
+
+Content: 
+Strong habits give you a safety net when motivation is low, but it helps to plan for disruptions. Restarting your cue–routine link quickly after a break makes habits much easier to recover. Now it’s your turn to practice identifying good habit “recipes.” Can you tell which of the next four quotes have strong cues, simple routines, and repetition built in? Remember: the best habits start small, attach to reliable cues, and repeat often.
+
+********************************************************************
+L07-S20-G171 | Lesson 7 Slide 20/32 | Global 171/271
+
+***DO NOT REFERENCE***
+
+Title: Quiz question
+
+********************************************************************
+L07-S21-G172 | Lesson 7 Slide 21/32 | Global 172/271
+
+***DO NOT REFERENCE***
+
+Title: Quiz question
+
+********************************************************************
+L07-S22-G173 | Lesson 7 Slide 22/32 | Global 173/271
+***DO NOT REFERENCE***
+
+Title: Quiz question
+
+********************************************************************
+L07-S23-G174 | Lesson 7 Slide 23/32 | Global 174/271
+
+***DO NOT REFERENCE***
+
+Title: Quiz question
+
+********************************************************************
+L07-S24-G175 | Lesson 7 Slide 24/32 | Global 175/271
+
+***DO NOT REFERENCE***
+
+Title: Reflection
+
+********************************************************************
+L07-S25-G176 | Lesson 7 Slide 25/32 | Global 176/271 
+
+***DO NOT REFERENCE***
+
+Title: How to use app to set habit recipe (video)
+
+********************************************************************
+L07-S26-G177 | Lesson 7 Slide 26/32 | Global 177/271
+
+***DO NOT REFERENCE***
+
+Title: How to use app to set habit recipe (reminders) 
+
+********************************************************************
+L07-S27-G178 | Lesson 7 Slide 27/32 | Global 178/271
+
+Title: Key takeaways
+
++++
+
+Content: 
+Habits are reflexive processes triggered by cues in your environment that make activity feel more automatic. While physical activity itself fully automatic, habit-based cues help cut through the effort barrier at the instigation stage. The recipe is simple: Cue + Routine + Repetition. Strong cues are specific and consistent. Habits support you when motivation is low but can weaken with disruptions, so creating backup cues and habits is essential for building lasting enjoyment and identity.
+
+********************************************************************
+L07-S28-G179 | Lesson 7 Slide 28/32 | Global 179/271
+
+***DO NOT REFERENCE***
+
+Title: Quiz question
+
+********************************************************************
+L07-S29-G180 | Lesson 7 Slide 29/32 | Global 180/271
+
+***DO NOT REFERENCE***
+
+Title: Quiz question
+
+********************************************************************
+L07-S30-G181 | Lesson 7 Slide 30/32 | Global 181/271 
+
+***DO NOT REFERENCE***
+
+Title: Quiz question
+
+********************************************************************
+L07-S31-G182 | Lesson 7 Slide 31/32 | Global 182/271
+
+***DO NOT REFERENCE***
+
+Title: Reflection
+
+********************************************************************
+L07-S32-G183 | Lesson 7 Slide 32/32 | Global 183/271
+
+***DO NOT REFERENCE***
+
+Title: Lesson complete
+
+=====================================================================
+LESSON 8: Habits That Last: Staying Active Through Change (29 slides)
+=====================================================================
+L08-S01-G184 | Lesson 8 Slide 1/29 | Global 184/271
+
+Lesson Description: This lesson will help you understand how habits change, what keeps them strong, how to handle disruptions, and why enjoying activity helps make habits stick.
+
+********************************************************************
+L08-S02-G185 | Lesson 8 Slide 2/29 | Global 185/271
+
+Title: What M-PAC says: Habits 
+
++++ 
+
+Content:
+The Multi-Process Action Control (M-PAC) framework explains that habits are crucial for sustaining physical activity over time.
+Early in retirement, many people rely on intentions, goal setting, and planning to get active. But as weeks and months pass, those conscious strategies may lose their power. That’s where habits step in. By repeating activity in stable contexts, environmental cues (like morning routines, favourite walking routes, or keeping exercise shoes by the door) begin to automatically trigger activity.
+In M-PAC, habits are the reflexive process that help you stay active long-term, providing an automatic trigger to keep moving, even when motivation dips. For example, if you always head out for a walk right after your morning coffee, retirement gives you the freedom to repeat that routine daily until it feels like second nature.
+
+********************************************************************
+L08-S03-G186 | Lesson 8 Slide 3/29 | Global 186/271
+
+Title: Why instigation habits matter for staying active
+
++++
+
+Content: 
+Why instigation habits matter for staying active in the long-term: 1) Research shows instigation habits are the strongest predictors of sustained physical activity compared to execution habits [1]. 2) They reduce reliance on fluctuating motivation or willpower, which often decline over time. 3) Without strong instigation habits, activity tends to drop off after structured programs, incentives, or support systems end. Building instigation habits early creates the foundation for long-term maintenance of physical activity, helping people stay active well into retirement and beyond. For example, packing a gym bag every afternoon becomes a reliable cue that gets you started, until it feels like second nature to head to the gym day after day.
+
+********************************************************************
+L08-S04-G187 | Lesson 8 Slide 4/29 | Global 187/271
+
+Title: Did you know?
+
++++
+
+Content:
+From the start of behavioural science, studies showed that over half of people drop out of physical activity programs within 6 months [2]. Modern reviews confirm this remains true today [3]. It’s so common it’s part of popular culture — from January joiners’ and short-lived resolutions to gyms that profit from unused memberships [4]. High early drop-off isn’t just a research finding — it’s a pattern most people recognize.
+
+********************************************************************
+L08-S05-G188 | Lesson 8 Slide 5/29 | Global 188/271
+
+Title: Habits and disruption
+
++++
+
+Content:
+Habits are powerful — but they’re also tied closely to the environment in which they were built. This means that even well-established habits can be disrupted when life changes. Why disruptions matter: Habits rely on stable cues, like breakfast, brushing teeth, or putting the kettle on. When those cues change — during travel, illness, family visits, or moving house — the automatic link between cue and behaviour can break down. Without the cue, the behaviour feels harder to initiate because you’re suddenly relying on willpower again.
+
+********************************************************************
+L08-S06-G189 | Lesson 8 Slide 6/29 | Global 189/271
+
+Title: The good news
+
++++
+
+Content:
+Disruption does not erase a habit pathway. The mental association you’ve built is still there, ready to be re-activated. Research shows that habits often come back more quickly the second time around, because the brain has already “learned” the pattern [5]. For example, if you usually walk after breakfast, travelling to a hotel without your usual breakfast routine may pause the habit. But once you’re home, the old breakfast–walk link is likely to restart quickly — much faster than it took to form the first time.
+
+********************************************************************
+L08-S07-G190 | Lesson 8 Slide 7/29 | Global 190/271
+
+***DO NOT REFERENCE***
+
+Title: Reflection prompt
+
+********************************************************************
+L08-S08-G191 | Lesson 8 Slide 8/29 | Global 191/271
+
+Title: Planning for habit disruption 
+
++++
+
+Content:
+Even strong habits can get disrupted, but the good news is they can be rebuilt quickly if you plan ahead. Key tip: Habits are like well-worn paths — they may fade if unused, but they never fully disappear. Walking them again soon makes them strong again.
+
+********************************************************************
+L08-S09-G192 | Lesson 8 Slide 9/29 | Global 192/271
+
+Title: How fast habits fade (and return)
+
++++
+
+Content:
+Habits feel automatic, but they’re not indestructible. If the cue–routine link is interrupted for long periods, habits can fade. What happens when habits fade: 1) Without the usual cue (like the kettle boiling or the evening news), the automatic response weakens. 2) Over time, the behaviour may feel less natural and require more conscious effort again. 3) This is why disruptions such as holidays, illness, or major life changes can lead to lapses in activity.
+
+********************************************************************
+L08-S10-G193 | Lesson 8 Slide 10/29 | Global 193/271
+
+Title: The good news
+
++++
+
+Content: 
+Habits rarely disappear completely. The mental association you’ve built is stored in memory. When the same cue returns, the habit pathway can reactivate quickly — much faster than it took to form the first time. Researchers describe this as “habit memory” — once learned, it’s easier to re- learn [5]. For example, you build a habit of stretching during the evening news. On holiday, there’s no news routine, so the habit pauses. When you return home and turn on the news, the stretching habit feels easier to restart than when you first began.
+
+********************************************************************
+L08-S11-G194 | Lesson 8 Slide 11/29 | Global 194/271
+
+***DO NOT REFERENCE***
+
+Title: Recap of if-then plans [6-8]
+
+********************************************************************
+L08-S12-G195 | Lesson 8 Slide 12/29 | Global 195/271
+
+Title: Did you know?
+
++++
+
+Content: 
+Habits and if–then plans work best together! Habits keep you consistent when cues are stable, while if–then plans add flexibility when routines are disrupted. Reviews of nearly 100 studies show if–then plans reliably boost health behaviours, including physical activity [7,8]. Staying active in retirement isn’t about perfection — it’s about pairing automatic habits with flexible plans so you can keep moving in any situation.
+
+********************************************************************
+L08-S13-G196 | Lesson 8 Slide 13/29 | Global 196/271
+
+Title: Example case: Habits with backup plans 
+
++++
+
+Content: 
+Meet David! David’s habit: “After I put on the kettle in the morning, I do 2 sets of strength exercises with resistance bands.” Over time, the kettle boiling became David’s cue to start the routine automatically. But some days don’t go as planned: Visitors in the house, Feeling low on energy or Travelling without his bands. That’s where his if–then plans help: If the living room is busy with visitors then I’ll do my bands in the bedroom instead, If I feel too tired then I’ll do just 1 set to keep the habit alive and If I’m travelling without bands then I’ll do 10 bodyweight squats instead. Habits make his morning exercise automatic, but if–then plans give him flexibility. Together, they keep his strength routine consistent even when life changes.
+
+********************************************************************
+L08-S14-G197 | Lesson 8 Slide 14/29 | Global 197/271
+
+***DO NOT REFERENCE***
+
+Title: Activity: Spot the strong habit and backup plan
+
+********************************************************************
+L08-S15-G198 | Lesson 8 Slide 15/29 | Global 198/271
+
+***DO NOT REFERENCE***
+
+Title: Reflection 
+
+********************************************************************
+L08-S16-G199 | Lesson 8 Slide 16/29 | Global 199/271
+
+Title: Did you know?
+
++++
+
+Content: 
+A recent study [9] found that habit strategies shift with experience. Novices need to explore enjoyable activities to make habits stick. Intermediates focus on commitment and consistency as motivation fades. Experts rely on effortless self-regulation, shaping environments and routines that make activity the easy choice. Habit formation looks different at each stage — from experimenting early, to building commitment, to eventually making activity feel natural and automatic.
+
+********************************************************************
+L08-S17-G200 | Lesson 8 Slide 17/29 | Global 200/271
+
+***DO NOT REFERENCE***
+
+Title: Quick recap: what is affect?
+
+********************************************************************
+L08-S18-G201 | Lesson 8 Slide 18/29 | Global 201/271
+
+Title: Did you know?
+
++++
+
+Content:
+Positive feelings are one of the strongest drivers of habit formation. When activity feels more enjoyable, your brain links the cue–routine pairing with a positive outcome. This emotional “glue” makes it more likely the behaviour will become automatic over time. On the other hand, negative feelings can weaken the habit loop — unless you find strategies to manage them (like starting small, using music, or slowing your pace). Habits depend not just on repetition, but also on how good the activity feels.
+
+********************************************************************
+L08-S19-G202 | Lesson 8 Slide 19/29 | Global 202/271
+
+Title: What the evidence shows: Habits and hedonic motivation
+
++++
+
+Content:
+Recent research shows that habits and hedonic motivation (the drive for pleasure and enjoyment) often work together to influence health behaviours [12]. Key points: 1) Habits are automatic cue–response links that get you started. 2) Hedonic motivation comes from the feelings you experience during or after activity — liking it, or anticipating enjoyment. 3) When activities feel good, hedonic motivation reinforces the behaviour, making it more likely you’ll repeat it in response to the same cue. Over time, this strengthens the habit loop.
+
+********************************************************************
+L08-S20-G203 | Lesson 8 Slide 20/29 | Global 203/271
+
+Title: Why this matters
+
++++
+
+Content:
+You don’t have to choose between “discipline” (habits) and “enjoyment” (affect). Both work together. The more you enjoy the routine, the faster it can become a habit. Targeting both habit and positive feelings may be one of the best strategies for long-term maintenance. For example, you start a habit of going for a morning swim after breakfast. At first, it takes effort, but soon you notice how refreshed and energized you feel afterward. That positive feeling makes you want to repeat it — strengthening both the hedonic motivation and the breakfast–swim habit. Over time, the swim becomes an automatic and enjoyable part of your retirement routine.
+
+********************************************************************
+L08-S21-G204 | Lesson 8 Slide 21/29 | Global 204/271
+
+Title: What the evidence shows: Commonalties of habit and hedonic motivation
+
++++
+
+Content:
+Although distinct, habits and hedonic motivation share important similarities [12] Commonalities: 1) Both are often considered automatic influences on behaviour. 2) Both are frequently triggered by cues in the environment. 3) Both are built through associative learning — repeating the behaviour in the same context strengthens the link. 4) Both can still be shaped by reflection and reasoning, not just unconscious processes. For example, an evening walk may run on habit (cue = finishing dinner) and hedonic motivation (you look forward to the calm and fresh air). Both processes nudge you in the same direction.
+
+********************************************************************
+L08-S22-G205 | Lesson 8 Slide 22/29 | Global 205/271
+
+***DO NOT REFERENCE***
+
+Title: Reflection prompt
+
+********************************************************************
+L08-S23-G206 | Lesson 8 Slide 23/29 | Global 206/271
+
+Title: What the evidence shows: Distinction between habit and hedonic motivation 
+
++++
+
+Content:
+Despite overlaps, there are key differences between the two [12]. Key distinctions: 1) Habit: A cue–response association. Habits can persist even if you no longer expect a reward. 2) Hedonic motivation: A value-based drive. It depends entirely on how the behaviour feels (liking/disliking, wanting/dreading). 3) Role of affect: Habits don’t require ongoing positive feelings to remain strong, while hedonic motivation is fully tied to affective consequences. 4) Interaction: Pleasant experiences can accelerate habit formation, but once a habit is established, it can carry on without continuous enjoyment.
+
+********************************************************************
+L08-S24-G207 | Lesson 8 Slide 24/29 | Global 207/271
+
+Title: Main takeaways
+
++++
+
+Content: Here are the main takeaway points from the lesson: 1) Habits make getting started easier by linking activity to cues. 2) Disruptions can break routines, but habits usually restart faster once cues return. 3) Affect (feelings) strengthens habits: the more you enjoy an activity, the more likely it will stick. 4) Hedonic motivation (pleasure/enjoyment) and habits work hand in hand — together, they make physical activity both automatic and rewarding. 5) In practice: tie activity to daily cues, plan for disruptions, and choose activities you enjoy — those are the ones that last.
+
+********************************************************************
+L08-S25-G208 | Lesson 8 Slide 25/29 | Global 208/271 
+
+***DO NOT REFERENCE***
+
+Title: Quiz question
+ 
+********************************************************************
+L08-S26-G209 | Lesson 8 Slide 26/29 | Global 209/271
+
+***DO NOT REFERENCE***
+
+Title: Quiz question
+ 
+********************************************************************
+L08-S27-G210 | Lesson 8 Slide 27/29 | Global 210/271
+
+***DO NOT REFERENCE***
+
+Title: Quiz question
+ 
+********************************************************************
+L08-S28-G211 | Lesson 8 Slide 28/29 | Global 211/271
+
+***DO NOT REFERENCE***
+
+Title: References
+ 
+********************************************************************
+L08-S29-G212 | Lesson 8 Slide 29/29 | Global 212/271
+
+***DO NOT REFERENCE***
+
+Title: Lesson complete
+
+======================================================================================
+LESSON 9: Who You Are When You Move: Understanding and Building Identities (30 slides)
+======================================================================================
+L09-S01-G213 | Lesson 9 Slide 1/30 | Global 213/271 
+
+Lesson Description: This lesson will his lesson will show how repeated behaviour, behavioural regulation, confidence, and imagination work together to strengthen your physical activity identity — your sense of being an active person.
+
+********************************************************************
+L09-S02-G214 | Lesson 9 Slide 2/30 | Global 214/271
+
+Title: What M-PAC says: Identity
+
++++
+
+Content:
+The Multi-Process Action Control (M-PAC) framework explains that our sense of identity, this is, how we see ourselves, plays a big role in sustaining physical activity over time. When people first retire, they often rely on intentions, goals, and plans to be active. But as routines settle in, those conscious strategies may fade. That’s when physical- activity identities play an important role in helping behaviour feel more natural and self-driven. If you start to think of being active as part of who you are, your choices naturally line up with that self-view. Instead of asking, “Should I exercise today?” you start thinking, “I’m the kind of person who moves every day.”
+
+********************************************************************
+L09-S03-G215 | Lesson 9 Slide 3/30 | Global 215/271
+
+Title: How identity sustains physical activity
+
++++
+
+Content:
+In M-PAC, identity helps people stay active long-term by guiding action toward what “fits” with who they believe themselves to be. For example, if you see yourself as an active retiree, you’re more likely to notice and take opportunities to move — choosing to walk to the shops, join a local class, or invite a friend for a hike — because those actions align with how you see yourself.
+
+********************************************************************
+L09-S04-G216 | Lesson 9 Slide 4/30 | Global 216/271
+
+Title: How physical activity identies form: Role-categorization
+
++++
+
+Content:
+According to the M-PAC framework, identities form when people begin to see themselves as holding a particular role, such as an active person, a walker, or an active retiree [1,2]. This process, called role-categorization, means that we classify ourselves in the same way we might classify others. Over time, repeated experiences, feedback, and cues strengthen that role and make it feel like part of who we are.
+
+********************************************************************
+L09-S05-G217 | Lesson 9 Slide 5/30 | Global 217/271
+
+Title: Why it matters
+
++++
+
+Content: 
+Physical-activity identities develop when people repeatedly act in ways that fit an “active” role and start to define themselves through that behaviour. For example, if you regularly join a walking group, you might first see it as “something I do.” But as the weeks go on, you start thinking, “I’m one of the walkers.” The behaviour becomes linked to your role and sense of self. Once a physical-activity role becomes part of your identity, it helps guide choices automatically. This means you’re drawn to act in ways that fit that role, much like a parent naturally cares for their child or a volunteer looks for ways to help others.
+
+********************************************************************
+L09-S06-G218 | Lesson 9 Slide 6/30 | Global 218/271
+
+Title: What the evidence shows 
+
++++
+
+Content: 
+Research shows that when people see being active as part of who they are, they’re much more likely to follow through on their intentions and stay active over time. A large review of more than 60 studies found a strong link between how much people see themselves as active and how active they actually are. In fact, identity was one of the strongest psychological factors related to being active - even more powerful than motivation, confidence, or attitudes toward exercise [3]. Identity doesn’t just sit on top of other psychological factors - it helps bind them to behaviour. When being active feels central to who you are, your goals, plans, and habits all work together more easily.
+
+********************************************************************
+L09-S07-G219 | Lesson 9 Slide 7/30 | Global 219/271
+
+Title: What the research found 
+
++++
+ 
+Content:
+1) People with a strong activity identity showed greater commitment, confidence, and positive feelings about being active. 2) Identity was linked with higher self-regulation, intention strength, and follow-through. 3) It also helped bridge the gap between intentions and action – people with an active identity were more likely to turn plans into behaviour. 4) When behaviour didn’t match identity (e.g., “I’m active” but not exercising), people experienced discomfort – a push to re-align their actions with their self-view. For example, if you see yourself as an active person, missing a week of walks may feel “off.” That tension often motivates a return to activity, not out of guilt, but to stay consistent with your self-image.
+Building an active identity strengthens the whole system - your goals, plans, emotions, and habits start working in the same direction, making physical activity feel natural and self-consistent.
+
+********************************************************************
+L09-S08-G220 | Lesson 9 Slide 8/30 | Global 220/271
+
+Title: Grow the identity that moves you forward
+
++++
+
+Content: 
+The video shows how older adults stay active by shifting goals from performance and comparison to meaning, consistency, and enjoyment. Instead of chasing times or wins, they focus on goals that support identity (“I’m an active person”), health, and long-term sustainability. This reframing helps maintain motivation and follow-through as abilities change with age.
+
+********************************************************************
+L09-S09-G221 | Lesson 9 Slide 9/30 | Global 221/271
+
+Title: Building blocks of a physical activity identity 
+
++++
+
+Content:
+Your physical activity identity doesn’t happen overnight, it’s built over time through your actions, thoughts, and connections. These are the three building blocks that work together to shape how strongly you see yourself as an active person: Cognitive blocks (how you think about yourself), behavioural blocks (what you regularly do), and social blocks (who you connect with). Together, these three building blocks help you develop and strengthen your sense of being an active person.
+
+********************************************************************
+L09-S10-G222 | Lesson 9 Slide 10/30 | Global 222/271
+
+Title: Behavioural building block: what you do (Be physically active)
+
++++
+
+Content:
+Repeated and consistent participation in physical activity is one of the strongest ways to build an active identity. Each time you move, you provide evidence to yourself that you are a physically active person. Research shows a strong connection between past physical activity and developing an active identity. In fact, people who regularly engage in physical activity are more likely to see being active as part of who they are — and this identity, in turn, predicts future activity [4,5].
+
+********************************************************************
+L09-S11-G223 | Lesson 9 Slide 11/30 | Global 223/271
+
+Title: Why this matters
+
++++
+
+Content: 
+Every walk, stretch, or class you complete isn’t just good for your health — it reinforces your self-view as someone who moves. Over time, those actions make activity feel more natural and self-driven. This idea fits with other self-theories in psychology [6]: Self-perception theory: we learn who we are by observing what we do and Self-verification theory: we act in ways that confirm our self-view. For example, when you complete your planned activities for the week, take a moment to note: “That’s evidence that I’m a physically active person.” By linking each effort to your identity, you strengthen the mental connection between doing and being - turning your behaviour into part of your story.
+
+********************************************************************
+L09-S12-G224 | Lesson 9 Slide 12/30 | Global 224/271
+
+Title: Behavioural building block: what you do (plan and track your activity)
+
++++
+
+Content:
+Behavioural regulation means managing your actions in line with your goals- for example, setting plans, tracking progress, and adjusting when things don’t go as expected. Behavioural regulation is more than a tool for behaviour-change it also helps shape and strengthen your physical activity identity. When you plan, monitor, and follow through on activity, you’re not just organizing your time - you’re reinforcing that being active matters to you and is part of who you are. Tracking progress with fitness apps or wearables, or problem-solving around barriers, often deepens commitment and self-belief. It signals to yourself, “I invest effort in this because it’s important to who I am.”
+
+********************************************************************
+L09-S13-G225 | Lesson 9 Slide 13/30 | Global 225/271
+
+Title: Behavioural regulation strengths identity 
+
++++
+
+Content:
+For example, You schedule gym or yoga sessions in your calendar each week, review your smartwatch data to see how your mobility or step goals are trending and make a “Plan B” for when bad weather or travel gets in the way—like swapping tennis for resistance bands at home. Each of these acts is a form of behavioural regulation. Together, they strengthen the story: “I’m someone who stays active and follows through". Pro tip: Keep using the strategies from earlier lessons: goal setting, action planning, self-monitoring, and if-then plans. These behaviour regulation skills do more than improve consistency. Every time you plan ahead, adjust to challenges, or follow through, you reinforce that being active is part of who you are. People who plan, track, and adapt their routines report a stronger sense that “being active” is part of their identity [6,7].
+
+********************************************************************
+L09-S14-G226 | Lesson 9 Slide 14/30 | Global 226/271
+
+Title:  Behavioural regulation strengthens identity (Invest time and energy into active you)
+
++++
+
+Content: 
+Investing in physical activity means putting your time, effort, or resources toward being active. It could be as simple as setting aside part of your day for exercise or as involved as signing up for lessons, buying equipment, or joining a club. People who dedicate time or resources to physical activity tend to see it as an important part of who they are. Studies show that actions like talking about exercise, purchasing equipment or memberships, or planning activities with others help reinforce an active identity [8,9]. Investment works because it’s identity-confirming: when we spend time, money, or effort on being active, it sends the message, both to ourselves and others – “this matters to me.”
+
+********************************************************************
+L09-S15-G227 | Lesson 9 Slide 15/30 | Global 227/271
+
+Title: Invest in your active self 
+
++++
+
+Content:
+For example: Buying new golf clubs, resistance bands, or hiking boots, Scheduling a weekly pickleball match or personal-training session, Choosing a mobility or yoga class instead of watching TV, Signing up for a local tennis or charity event, Reading about strength training or listening to podcasts on active living. Each choice represents a small but powerful investment—evidence that you’re committed to living as an active person. Pro tip: Look for ways to make your investment visible and meaningful. Write down one way you’ll invest this month—time, energy, or resources—and note how it supports the kind of active retiree you want to be.
+
+********************************************************************
+L09-S16-G228 | Lesson 9 Slide 16/30 | Global 228/271
+
+Title: How behaviour shapes identity
+
++++
+
+Content:
+Example: Meet Joan! Joan recently retired after 35 years in education, At first, she joined a twice-weekly mobility class “just to stay limber.” She also began tracking her activity on her smartwatch and made if–then plans to help keep her routine going: “If my mobility class is cancelled, then I’ll do my stretches at home during that same time.” Over time… Joan noticed small changes. She started talking with friends about fitness podcasts, picked up some new Lululemon workout clothes, and signed up for a charity hike. What changed? Through repeated action (physical activity), planning and tracking (self-regulation), and putting in effort and resources (investment), Joan’s view of herself shifted from “someone trying to be active” to “I’m an active person.” Now, being active feels natural, is a regular part of her week and her identity as a newly retired professional who values health, energy, and connection. Your behaviour is more than what you do — it’s evidence of who you are becoming. Each decision to move, plan, or invest adds another piece to your active-person identity.
+
+********************************************************************
+L09-S17-G229 | Lesson 9 Slide 17/30 | Global 229/271 
+
+Title: Cognitive building block: how you think (perceived ability)
+
++++
+
+Content:
+Feeling capable is central to building an active identity. When people believe they can successfully take part in physical activity, they’re more likely to see being active as part of who they are [6]. Repeated confidence is build through consistent success turns "I can do this" into "This is who I am".
+
+********************************************************************
+L09-S18-G230 | Lesson 9 Slide 18/30 | Global 230/271
+
+Title: Cognitive building block: how you think
+
++++
+
+Content:
+Start small, succeed often: Set goals you can realistically achieve, and celebrate each success. Reflect on progress: Notice how far you’ve come since starting the program. Learn from others: Watch or talk with people like you who have built regular activity into their lives—whether that’s a friend in your class or someone at the gym who started later in life. Seek feedback: Ask supportive people to point out your improvements—small or large. When someone first starts a new activity, they may feel unsure about their strength or ability. Over time, noticing small improvements—moving more easily, feeling steadier, or hearing positive feedback like “you’ve really improved”—can make a big difference.
+
+********************************************************************
+L09-S19-G231 | Lesson 9 Slide 19/30 | Global 231/271
+
+Title: Did you know?
+
++++
+
+Content:
+People tend to pursue versions of themselves they believe they can achieve. Studies show that confidence — or self-efficacy — is one of the strongest predictors of developing an active identity. Each small success reinforces the message: “This is who I am.” [3,10].
+
+********************************************************************
+L09-S20-G232 | Lesson 9 Slide 20/30 | Global 232/271
+
+Title: Cognitive building block: how you think (Imaginal experiences)
+
++++
+
+Content:
+Imagining yourself as a physically active person can help bring that version of you to life. When you picture what being active looks and feels like, it starts to shift how you see yourself right now. Creating a clear picture of your future active self can help strengthen your identity as an active person in the present. When people picture themselves as a “physically active retiree,” they often strengthen their sense of being an active person [11,12]. Regularly reflecting on that image can help keep motivation high and on track toward retirement [6]. Visualizing your possible self — who you want to become — may also inspire you to set goals, plan ahead, and invest in behaviours that make that image real [12].
+
+********************************************************************
+L09-S21-G233 | Lesson 9 Slide 21/30 | Global 233/271
+
+***DO NOT REFERENCE***
+
+Title: Reflection prompt
+
+********************************************************************
+L09-S22-G234 | Lesson 9 Slide 22/30 | Global 234/271
+
+Title: Define what “active” means to you (Rules and standards)
+
++++
+
+Content:
+Having clear personal rules or standards for what it means to be a physically active person can make your identity more concrete and motivating. When you know what “being active” looks like for you, it’s easier to recognize when your actions match your identity. Studies suggest that having clear standards around physical activity, such as how often, how long, or what types of movement count — can help people live more consistently with their active identity [13]. When we behave in ways that match our self-view, that behaviour reinforces who we believe ourselves to be [14].
+
+********************************************************************
+L09-S23-G235 | Lesson 9 Slide 23/30 | Global 235/271
+
+Title: Flexibility strengthens your active identity
+
++++
+
+Content: 
+Researchers also caution that narrow or rigid rules (“I’m only active if I run five times a week”) may make it harder to confirm that identity in real life. Broader, flexible standards (“I’m active when I move regularly and feel engaged in my body”) make it easier to sustain confidence and consistency. For example, someone might define being active as “moving their body with purpose at least four times per week.” Some weeks that could mean yoga, hiking, or mobility work; other weeks, longer walks or pickleball. Keeping this definition flexible helps people feel successful and aligned with their identity — even when routines change.
+
+********************************************************************
+L09-S24-G236 | Lesson 9 Slide 24/30 | Global 236/271
+
+***DO NOT REFERENCE***
+
+Title: Reflection prompt 
+
+********************************************************************
+L09-S25-G237 | Lesson 9 Slide 25/30 | Global 237/271
+
+Title: Main lesson takeaways
+
++++
+
+Content:
+Here are the main takeaway points from the lesson: 1) Doing becomes being: Repeated and consistent activity helps shape your self-view as an active person. 2) Self-regulation matters: Planning, tracking, and adjusting your activity shows that being active is important to you. 3) Investing in activity: Your time, energy, or resources strengthens commitment and reinforces your active identity. 4) Confidence grows identity: Each success or piece of positive feedback reminds you that you can be active and that you are an active person. 5) Imagination helps action: Visualizing your possible future active self keeps your goals alive and connects who you want to be with what you do today. 6) Personal rules and standards make your active identity more concrete and realistic, helping you recognize when your actions align with who you’re becoming.
+
+********************************************************************
+L09-S26-G238 | Lesson 9 Slide 26/30 | Global 238/271
+
+***DO NOT REFERENCE***
+
+Title: Quiz question
+
+********************************************************************
+L09-S27-G239 | Lesson 9 Slide 27/30 | Global 239/271
+
+***DO NOT REFERENCE***
+
+Title: Quiz question
+
+********************************************************************
+L09-S28-G240 | Lesson 9 Slide 28/30 | Global 240/271
+
+***DO NOT REFERENCE***
+
+Title: Quiz question
+
+********************************************************************
+L09-S29-G241 | Lesson 9 Slide 29/30 | Global 241/271
+
+***DO NOT REFERENCE***
+
+Title: References
+
+********************************************************************
+L09-S30-G242 | Lesson 9 Slide 30/30 | Global 242/271
+
+***DO NOT REFERENCE***
+
+Title: Lesson complete
+
+================================================================
+LESSON 10: Staying Connected and True to Your Values (29 slides)
+================================================================
+L10-S01-G243 | Lesson 10 Slide 1/29 | Global 243/271
+
+Lesson Description: This lesson explores how aligning your activity with your personal values, Description: relationships, and community can make physical activity more meaningful and lasting helping turn “what you do” into “who you are.”
+
+********************************************************************
+L10-S02-G244 | Lesson 10 Slide 2/29 | Global 244/271
+
+Title: What M-PAC says
+
++++
+
+Content:
+
+In the Multi-Process Action Control (M-PAC) framework, identity doesn’t develop in isolation - it’s shaped by the people and goals that matter most to you. When physical activity fits with your broader life values and relationships, it’s easier to sustain over time [1,2]. Identity doesn’t just describe who you are - it guides what you do.Those who see themselves as active people are more likely to notice and seize opportunities to move, even in small ways, because those actions feel consistent with their self-view. Over time, this alignment helps activity feel more natural and less dependent on willpower or planning. In M-PAC, identity functions as a reflexive process - it keeps behaviour aligned with intentions, even when motivation dips or routines change.
+
+********************************************************************
+L10-S03-G245 | Lesson 10 Slide 3/29 | Global 245/271
+
+Title: Actions that reflect who you are
+
++++
+
+Content: 
+Identities grow stronger when behaviour feels both personally meaningful and socially reinforced. For example, someone who identifies as “an active retiree” may instinctively choose to walk to the store, stretch during TV time, or accept a friend’s invite to play pickleball, because those choices fit who they believe themselves to be.
+
+********************************************************************
+L10-S04-G246 | Lesson 10 Slide 4/29 | Global 246/271
+
+***DO NOT REFERENCE***
+
+Title: More about the building blocks 
+
+********************************************************************
+L10-S05-G247 | Lesson 10 Slide 5/29 | Global 247/271
+
+Title: Cognitive block: how you think (Alignment with your values and core identities
+
++++
+
+Content:
+Your physical activity identity becomes stronger when it connects with other important parts of who you are - like being a partner, friend, volunteer, or someone who values health, purpose, or community. When physical activity supports your core identities rather than competes with them, it feels more natural and sustainable. For example, a recent retiree who values community and connection might join a walking group or volunteer to lead gentle exercise classes, reinforcing both their active and community-minded identities at once. Aligning your physical activity identity with your other core identities or values helps reduce conflict and makes being active feel authentic. It becomes part of your larger sense of self.
+
+********************************************************************
+L10-S06-G248 | Lesson 10 Slide 6/29 | Global 248/271 
+
+Title: Did you know?
+
++++
+
+Content: 
+People are more likely to keep being active when movement fits with what matters most to them. Research suggests that when physical activity is integrated with other meaningful roles or values, like family, productivity, or caring for others, both identities are strengthened [2,3].
+
+********************************************************************
+L10-S07-G249 | Lesson 10 Slide 7/29 | Global 249/271
+
+***DO NOT REFERENCE***
+
+Title: Reflection prompt
+
+********************************************************************
+L10-S08-G250 | Lesson 10 Slide 8/29 | Global 250/271
+
+Title: Help with standing connected to your values
+
++++
+
+Content:
+You’ve seen how identity and values make activity meaningful - now, let’s explore a simple framework that helps you stay connected to those values even when challenges arise.
+
+********************************************************************
+L10-S09-G251 | Lesson 10 Slide 9/29 | Global 251/271
+
+Title: What is Acceptance and Commitment Therapy (ACT)?
+
++++
+
+Content:
+
+Acceptance and Commitment Therapy (ACT) is a behaviour-based psychological approach designed to help people manage emotions and take meaningful actions aligned with their values [4]. ACT helps you to: Accept your thoughts and feelings and be present, choose a valued direction and take committed actions toward meaningful goals. Researchers call this skill psychological flexibility — the ability to notice emotions and thoughts without letting them take over and still act in ways that support what matters most [5]. In physical activity, ACT skills mean you can keep moving even when stress, tiredness, or “I don’t feel like it” show up — because you’re guided by your deeper values, like health, independence, or enjoyment.
+
+********************************************************************
+L10-S10-G252 | Lesson 10 Slide 10/29 | Global 252/271
+
+Title: The six core processes of ACT
+
++++
+
+Content:
+ACT is built on six core processes that work together to build psychological flexibility [4]: 1) Acceptance: Making space for difficult emotions without judgment. 2) Defusion: Creating distance from unhelpful thoughts so they have less power. 3) Present-Moment Awareness: Staying engaged in the here and now. 4) Values: Identifying what truly matters to you (e.g., health, independence, enjoyment). 5) Committed Action: Taking meaningful steps in line with your values, even when things are challenging. 5) Self-as-Context: Recognizing the “observer you” that notices thoughts and feelings.
+
+********************************************************************
+L10-S11-G253 | Lesson 10 Slide 11/29 | Global 253/271
+
+Title: What the evidence shows
+
++++
+
+Content:
+Evidence for ACT in physical activity is still emerging, but early findings are promising: University students: ACT-based workshops improved exercise adherence and self-reported physical activity, helping students persist with routines over time [6]. Lifestyle change programs: ACT strategies supported people in managing weight by helping them cope with discomfort and stay committed to increasing their physical activity [7]. Digital health interventions: ACT-based mobile programs helped adults increase physical activity and reduce sitting time, showing potential for scalable electronic or mobile health approaches [8]. Overall, reviews show ACT is an evidence-based way to support health-related behaviour change broadly [4,5]. In simple terms: ACT helps people stay active by focusing on their values and long- term goals, even when motivation dips or emotions get in the way.
+
+********************************************************************
+L10-S12-G254 | Lesson 10 Slide 12/29 | Global 254/271
+
+Title: Why ACT matters for physical activity
+
++++
+
+Content: 
+Retirement can bring new routines, more free time, and sometimes unexpected challenges like changing health, stress, or fluctuating energy levels. These can all affect how you feel about being active. ACT matters because it helps you stay active even when those challenges arise. By focusing on your values — like health, independence, enjoyment, or being there for family — ACT encourages you to take action that matches what matters most to you. For example: 1) If you feel too tired for your planned aerobic activity (like a cycle ride), ACT can help you accept the feeling of fatigue, but still choose a lighter ride because staying mobile supports your independence. 2) If you feel unmotivated before a strength session, ACT reminds you that keeping your body strong helps you continue hobbies you enjoy, like gardening or travel. 3) If a low mood makes you want to skip flexibility exercises, ACT encourages you to connect your value of health and do a short routine, knowing it supports comfort and mobility in daily life. 4) In short, ACT matters because it connects daily activity to your deeper values, helping you stay consistent in the long run. ACT helps you move through challenges instead of waiting for them to disappear.
+
+********************************************************************
+L10-S13-G255 | Lesson 10 Slide 13/29 | Global 255/271
+
+Title: ACT in action
+
++++
+
+Content:
+Here’s how ACT can help with common barriers to activity: 1) Feeling fatigued = Aerobic: Accept the tiredness, but remind yourself: “Even a short walk supports my independence.” (acceptance + values), Strength: Defuse from the thought “I’m too weak today” by noticing it is just a thought, then do a light resistance set (defusion), Flexibility: Commit to a 10-minute stretch, guided by your value of health, even if you don’t feel like it (committed action). 2) Low motivation = Aerobic: Notice the thought “I don’t want to” without judgment, then choose to cycle because staying active supports enjoyment of hobbies (defusion + values), Strength: Reconnect to your value of independence: “Keeping strong helps me carry groceries.” (values), Flexibility: Do a short yoga or tai chi routine, accepting the low motivation but acting in line with health goals. (acceptance + committed action). 3) Stress or low mood =  Aerobic: Use present-moment awareness — focus on the rhythm of swimming strokes to calm the mind (present-moment awareness), Strength: Accept the stress and remind yourself: “This set helps me release tension.” (acceptance) Flexibility: Connect to values: stretching helps you feel comfortable and mobile to enjoy daily activities (values).
+
+********************************************************************
+L10-S14-G256 | Lesson 10 Slide 14/29 | Global 256/271
+
+***DO NOT REFERENCES***
+
+Title: How to identify your core values 
+
+********************************************************************
+L10-S15-G257 | Lesson 10 Slide 15/29 | Global 257/271
+
+Title: The umbrella analogy 
+
++++
+
+Content:
+Think of your emotions like the weather. Some days are sunny and calm, other days bring clouds, rain, or wind. Just like we can’t control the weather, we can’t always control our emotions. ACT is like carrying an umbrella. The umbrella represents your values — health, independence, enjoyment. Even if the weather isn’t perfect (stress, fatigue, low mood), your umbrella helps you keep going in the direction you’ve chosen. You don’t have to wait for the “perfect weather” to be active. You can accept how you feel and still move forward, guided by what matters most.
+
+********************************************************************
+L10-S16-G258 | Lesson 10 Slide 16/29 | Global 258/271
+
+Title: Social block: who you connect with
+
++++
+
+Content:
+Social appraisals: How others shape your active identity. Identity doesn’t develop in isolation — it’s shaped by the social world around you. Social appraisals are the ways we interpret others’ actions and feedback about physical activity — and they can powerfully influence how we see ourselves [9]. We naturally look to people around us to understand what “being active” means and how we measure up. When others model activity, share encouragement, or recognize our efforts, these cues reinforce our sense of belonging in the “active person” group [3].
+
+********************************************************************
+L10-S17-G259 | Lesson 10 Slide 17/29 | Global 259/271
+
+Title: Social support strengthens identity
+
++++
+
+Content:
+For example, when your walking group notices your consistency, or your instructor calls you “one of our regulars,” that feedback doesn’t just feel good — it confirms your identity as someone active and committed. M-PAC and identity theory suggest that seeing others being active and receiving encouragement from people around you both help connect what you do with who you are. When others model activity or offer support, it reinforces the feeling, “Yes — this is part of who I am” [3,9].
+
+********************************************************************
+L10-S18-G260 | Lesson 10 Slide 18/29 | Global 260/271
+
+Title: Did you know?
+
++++
+
+Content:
+Social connections do more than motivate us — they help shape who we are. When people receive positive feedback about being active, or compare themselves with others who model regular movement, their physical-activity identity becomes stronger and more stable over time [10]. Research with M-PAC and identity theory shows that these social reflections — like hearing encouragement or seeing active peers — help link behaviour and identity [3,9]. Each time someone recognizes your effort or you engage with others who value being active, it reinforces the sense that “This is part of who I am.”
+
+********************************************************************
+L10-S19-G261 | Lesson 10 Slide 19/29 | Global 261/271
+
+***DO NOT REFLECTION***
+
+Title: Reflection prompt
+
+********************************************************************
+L10-S20-G262 | Lesson 10 Slide 20/29 | Global 262/271
+
+Title: Social block: who you connect with
+
++++
+
+Content:
+Attached ties: How social bonds keep moving. Alongside the feedback and recognition, you receive (i.e., social appraisals), the connections you form with others through physical activity — known as attachment ties — play a powerful role in sustaining your active identity [9]. While social appraisal how other see you, attach ties reflect how connected you feel them. Both strengthen your identity but in different ways. Feeling emotionally connected to others in active settings — a walking partner, a class, a pickleball group, or an online fitness community — fosters belonging and enjoyment. Over time, those relationships make being active part of your social life and part of who you are. Research shows that people who develop social bonds through group exercise or shared activity settings report stronger motivation, confidence, and identity as active individuals [11]. Even online or virtual groups can offer a similar sense of belonging that supports ongoing activity [12].
+
+********************************************************************
+L10-S21-G263 | Lesson 10 Slide 21/29 | Global 263/271
+
+Title: What the evidence shows
+
++++
+
+Content: 
+Recent studies highlight just how powerful social belonging can be for sustaining physical activity. In a large parkrunners study, people who identified strongly as parkrunners attended more often, reported higher satisfaction, and experienced greater wellbeing and life satisfaction than those with weaker group identification [13]. Researchers describe this as social identification - feeling part of a group where being active is the norm. That sense of belonging promotes sustained participation, enjoyment, and even better overall health [14].
+
+********************************************************************
+L10-S22-G264 | Lesson 10 Slide 22/29 | Global 264/271
+
+Title: Finding connection and meaning through activity
+
++++
+
+Content: 
+When someone retires from full-time work, they may want to stay active but miss the structure and social connection their job once provided. At first, they might exercise alone a few times per week — which feels good, but still leaves something missing. After being introduced to a local activity group, they may feel hesitant to join. Over time, however, finding others who share their pace, humour, and enjoyment of being outdoors can turn the activity into a source of community. “It’s not just about fitness anymore,” one participant explains. “It’s about catching up with friends, helping newer members, and feeling like I belong.” Over time… That activity becomes part of their identity. Values: The activity aligns with what matters most — staying healthy, social, and independent. Social appraisals: Encouragement and recognition from peers (e.g., being seen as reliable or supportive) strengthen the belief that they are an active person. Attachment ties: Friendships make participation feel meaningful and connected, rather than like an obligation. Eventually, being active no longer feels like a task or goal. It becomes part of who they are — and part of a group that shares the same active identity.
+
+********************************************************************
+L10-S23-G265 | Lesson 10 Slide 23/29 | Global 265/271
+
+***DO NOT REFERENCE***
+
+Title: Reflection prompt
+
+********************************************************************
+L10-S24-G266 | Lesson 10 Slide 24/29 | Global 266/271
+
+Title: Main lesson takeaways 
+
++++
+
+Content:
+Identity grows through connection. When your activity reflects your values and relationships, it becomes more than something you do — it becomes part of who you are. Linking activity to what matters most, like health, independence, or community, helps you stay motivated over time. Encouragement and recognition from others also strengthen your belief that you are an active person. Walking partners, teammates, and exercise groups create belonging and enjoyment that make it easier to stay consistent. In M-PAC, these social influences — your values, social appraisals, and connection ties — help turn intentions into lasting habits. The more you link your activity to what and who you care about, the easier it becomes to keep moving for the long run.
+
+********************************************************************
+L10-S25-G267 | Lesson 10 Slide 25/29 | Global 267/271
+
+***DO NOT REFERENCE***
+
+Title: Quiz question
+
+********************************************************************
+L10-S26-G268 | Lesson 10 Slide 26/29 | Global 268/271
+
+***DO NOT REFERENCE***
+
+Title: Quiz question
+
+********************************************************************
+L10-S27-G269 | Lesson 10 Slide 27/29 | Global 269/271
+
+***DO NOT REFERENCE***
+
+Title: Quiz question
+
+********************************************************************
+L10-S28-G270 | Lesson 10 Slide 28/29 | Global 270/271
+
+***DO NOT REFERENCE***
+
+Title: References
+
+********************************************************************
+L10-S29-G271 | Lesson 10 Slide 29/29 | Global 271/271
+
+***DO NOT REFERENCE***
+
+Title: Lesson complete 
+
+<<<<<<<<<<<<<<<<<<<<<<<<<END OF DATASET>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+

--- a/rag/__init__.py
+++ b/rag/__init__.py
@@ -1,0 +1,5 @@
+"""Local retrieval-augmented generation helpers."""
+
+from __future__ import annotations
+
+__all__ = ["config", "parsing_master", "parsing_activities", "ingest", "retriever", "router"]

--- a/rag/config.py
+++ b/rag/config.py
@@ -1,0 +1,98 @@
+"""Configuration helpers shared by the local RAG stack."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DATA_DIR = REPO_ROOT / "Data"
+
+MASTER_FILENAME = "reframing_retirement_master_data_set.txt"
+ACTIVITY_FILENAME = "reframing_retirement_activity_list.txt"
+
+EMBED_DIMENSIONS = {
+    "text-embedding-3-large": 3072,
+    "text-embedding-3-small": 1536,
+}
+
+
+def _path_from_env(var_name: str, default: Path) -> Path:
+    value = os.getenv(var_name)
+    if value:
+        return Path(value).expanduser()
+    return default
+
+
+def _coerce_int(value: Optional[str], fallback: int) -> int:
+    try:
+        return int(value) if value is not None else fallback
+    except ValueError:
+        return fallback
+
+
+def _read_openai_key() -> str:
+    key = os.getenv("OPENAI_API_key") or os.getenv("OPENAI_API_KEY")
+    if not key:
+        raise ValueError("Set OPENAI_API_key (preferred) or OPENAI_API_KEY in your environment.")
+    return key
+
+
+@dataclass
+class RagConfig:
+    """Holds runtime settings for ingestion and retrieval."""
+
+    openai_api_key: str
+    chat_model: str
+    embedding_model: str
+    embedding_dimensions: int
+    master_collection: str
+    activities_collection: str
+    qdrant_url: str
+    qdrant_api_key: Optional[str]
+    master_data_path: Path
+    activity_data_path: Path
+    master_top_k: int = 5
+    activity_top_k: int = 4
+
+
+def load_rag_config() -> RagConfig:
+    """Load configuration from .env with safe defaults."""
+
+    openai_api_key = _read_openai_key()
+    chat_model = os.getenv("OPENAI_MODEL", "gpt-4o")
+    embedding_model = os.getenv("OPENAI_EMBEDDING_MODEL", "text-embedding-3-large")
+    embedding_dimensions = EMBED_DIMENSIONS.get(embedding_model, 3072)
+
+    qdrant_url = os.getenv("QDRANT_URL", "http://localhost:6333")
+    qdrant_api_key = os.getenv("QDRANT_API_KEY")
+
+    master_collection = os.getenv("RR_MASTER_COLLECTION", "rr_master")
+    activities_collection = os.getenv("RR_ACTIVITIES_COLLECTION", "rr_activities")
+
+    master_data_path = _path_from_env("RR_MASTER_DATA_PATH", DATA_DIR / MASTER_FILENAME)
+    activity_data_path = _path_from_env("RR_ACTIVITY_DATA_PATH", DATA_DIR / ACTIVITY_FILENAME)
+
+    master_top_k = _coerce_int(os.getenv("RR_MASTER_TOP_K"), 5)
+    activity_top_k = _coerce_int(os.getenv("RR_ACTIVITY_TOP_K"), 4)
+
+    return RagConfig(
+        openai_api_key=openai_api_key,
+        chat_model=chat_model,
+        embedding_model=embedding_model,
+        embedding_dimensions=embedding_dimensions,
+        master_collection=master_collection,
+        activities_collection=activities_collection,
+        qdrant_url=qdrant_url,
+        qdrant_api_key=qdrant_api_key,
+        master_data_path=master_data_path,
+        activity_data_path=activity_data_path,
+        master_top_k=master_top_k,
+        activity_top_k=activity_top_k,
+    )

--- a/rag/ingest.py
+++ b/rag/ingest.py
@@ -1,0 +1,86 @@
+"""
+RAG INGEST INSTRUCTIONS
+1) Start Qdrant locally (e.g. `docker run -p 6333:6333 -p 6334:6334 qdrant/qdrant`).
+2) Run `python -m rag.ingest` to parse the datasets and upsert them into Qdrant.
+3) Run `python main.py` and confirm retrieval works inside the CLI.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Sequence
+
+from dotenv import load_dotenv
+from llama_index.core import Settings, StorageContext, VectorStoreIndex
+from llama_index.core.schema import TextNode
+from llama_index.embeddings.openai import OpenAIEmbedding
+from llama_index.vector_stores.qdrant import QdrantVectorStore
+from qdrant_client import QdrantClient
+from qdrant_client.models import Distance, VectorParams
+
+from rag.config import RagConfig, load_rag_config
+from rag.parsing_activities import ActivityChunk, parse_activity_file
+from rag.parsing_master import MasterChunk, parse_master_file
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+def _stable_uuid(value: str) -> str:
+    """Return a deterministic UUID for a given chunk id."""
+
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, value))
+
+
+def _to_nodes(chunks: Sequence[MasterChunk | ActivityChunk]) -> Sequence[TextNode]:
+    return [
+        TextNode(
+            text=chunk.text,
+            id_=_stable_uuid(chunk.chunk_id),
+            metadata=chunk.metadata,
+        )
+        for chunk in chunks
+    ]
+
+
+def _ensure_collection(client: QdrantClient, name: str, vector_size: int) -> None:
+    logger.info("Creating collection %s (size=%s)", name, vector_size)
+    client.recreate_collection(
+        collection_name=name,
+        vectors_config=VectorParams(size=vector_size, distance=Distance.COSINE),
+    )
+
+
+def _upsert_nodes(config: RagConfig, client: QdrantClient, collection: str, nodes: Sequence[TextNode]) -> None:
+    node_list = list(nodes)
+    vector_store = QdrantVectorStore(client=client, collection_name=collection)
+    storage_context = StorageContext.from_defaults(vector_store=vector_store)
+    VectorStoreIndex(nodes=node_list, storage_context=storage_context)
+    logger.info("Inserted %s nodes into %s", len(node_list), collection)
+
+
+def run_ingest() -> None:
+    load_dotenv()
+    config = load_rag_config()
+
+    Settings.embed_model = OpenAIEmbedding(model=config.embedding_model, api_key=config.openai_api_key)
+
+    logger.info("Parsing master dataset from %s", config.master_data_path)
+    master_chunks = parse_master_file(config.master_data_path)
+    logger.info("Parsing activity dataset from %s", config.activity_data_path)
+    activity_chunks = parse_activity_file(config.activity_data_path)
+
+    client = QdrantClient(url=config.qdrant_url, api_key=config.qdrant_api_key)
+
+    _ensure_collection(client, config.master_collection, config.embedding_dimensions)
+    _ensure_collection(client, config.activities_collection, config.embedding_dimensions)
+
+    _upsert_nodes(config, client, config.master_collection, _to_nodes(master_chunks))
+    _upsert_nodes(config, client, config.activities_collection, _to_nodes(activity_chunks))
+
+    logger.info("Ingestion complete.")
+
+
+if __name__ == "__main__":
+    run_ingest()

--- a/rag/parsing_activities.py
+++ b/rag/parsing_activities.py
@@ -1,0 +1,186 @@
+"""Parsing utilities for the activities dataset."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+CHUNK_DIVIDER = re.compile(r"\n\*{5,}\s*\n", flags=re.MULTILINE)
+HEADER_PATTERN = re.compile(r"(?P<id>\d+)\.\s*(?P<name>[^\n]+)")
+DAY_PATTERN = re.compile(
+    r"\b(Mondays?|Tuesdays?|Wednesdays?|Thursdays?|Fridays?|Saturdays?|Sundays?|Weekends?|Daily)\b",
+    flags=re.IGNORECASE,
+)
+
+TYPE_KEYWORDS = {
+    "yoga": ["yoga"],
+    "walking": ["walk", "walking"],
+    "pickleball": ["pickleball"],
+    "dance": ["dance", "zumba"],
+    "strength": ["strength", "resistance", "weights", "pilates"],
+    "aquatic": ["aqua", "swim", "water"],
+    "kayaking": ["kayak"],
+    "chair": ["chair"],
+    "mind-body": ["tai chi", "soqi", "somatic", "mobility"],
+}
+
+
+@dataclass
+class ActivityChunk:
+    """Represents a single local activity record."""
+
+    chunk_id: str
+    text: str
+    metadata: Dict[str, Any]
+
+
+def _split_chunks(text: str) -> Iterable[str]:
+    for piece in CHUNK_DIVIDER.split(text):
+        cleaned = piece.strip()
+        if cleaned:
+            yield cleaned
+
+
+def _extract_field(lines: List[str], label: str) -> str:
+    prefix = f"{label.lower()}:"
+    for line in lines:
+        lowered = line.lower().strip()
+        if lowered.startswith(prefix):
+            return line.split(":", 1)[1].strip()
+    return ""
+
+
+def _infer_cost_label(cost: str) -> str:
+    lowered = cost.lower()
+    if not lowered:
+        return "unknown"
+    if "free" in lowered or "no cost" in lowered:
+        return "free"
+    if any(char.isdigit() for char in cost) or "$" in cost:
+        return "paid"
+    return "unknown"
+
+
+def _extract_cost_value(cost: str) -> Optional[float]:
+    match = re.search(r"(\d+(?:\.\d+)?)", cost.replace(",", ""))
+    if match:
+        try:
+            return float(match.group(1))
+        except ValueError:
+            return None
+    return None
+
+
+def _normalize_days(when_text: str) -> List[str]:
+    days: List[str] = []
+    for match in DAY_PATTERN.finditer(when_text):
+        value = match.group(1).lower()
+        if value.startswith("mon"):
+            normalized = "Monday"
+        elif value.startswith("tue"):
+            normalized = "Tuesday"
+        elif value.startswith("wed"):
+            normalized = "Wednesday"
+        elif value.startswith("thu"):
+            normalized = "Thursday"
+        elif value.startswith("fri"):
+            normalized = "Friday"
+        elif value.startswith("sat"):
+            normalized = "Saturday"
+        elif value.startswith("sun"):
+            normalized = "Sunday"
+        elif value.startswith("weekend"):
+            normalized = "Weekend"
+        else:
+            normalized = "Daily"
+        days.append(normalized)
+    # preserve order but remove duplicates
+    seen = set()
+    unique_days = []
+    for day in days:
+        if day not in seen:
+            seen.add(day)
+            unique_days.append(day)
+    return unique_days
+
+
+def _infer_activity_type(name: str, description: str) -> str:
+    combined = f"{name} {description}".lower()
+    for label, keywords in TYPE_KEYWORDS.items():
+        if any(keyword in combined for keyword in keywords):
+            return label
+    return "general"
+
+
+def _location_aliases(location: str) -> List[str]:
+    lowered = location.lower()
+    aliases: List[str] = []
+    if "pear kes" in lowered or "gr pearkes" in lowered or "g.r. pearkes" in lowered:
+        aliases.extend(["saanich", "g. r. pearkes", "pearkes"])
+    if "silver threads" in lowered:
+        aliases.extend(["silver threads", "fernwood", "downtown", "fairfield"])
+    if "crystal pool" in lowered:
+        aliases.extend(["crystal pool", "fernwood", "downtown"])
+    if "cedar hill" in lowered:
+        aliases.append("cedar hill")
+    if "online" in lowered:
+        aliases.extend(["online", "virtual", "home"])
+    if "oak bay" in lowered or "uplands" in lowered:
+        aliases.extend(["oak bay", "uplands", "oak bay recreation centre"])
+    return aliases
+
+
+def parse_activity_file(path: Path) -> List[ActivityChunk]:
+    """Parse the activities dataset into structured chunks."""
+
+    if not path.exists():
+        raise FileNotFoundError(f"Activity dataset not found at {path}")
+
+    text = path.read_text(encoding="utf-8")
+    chunks: List[ActivityChunk] = []
+
+    for segment in _split_chunks(text):
+        header_match = HEADER_PATTERN.search(segment)
+        if not header_match:
+            continue
+
+        activity_id = int(header_match.group("id"))
+        name = header_match.group("name").strip()
+
+        lines = [line.strip() for line in segment.splitlines() if line.strip()]
+        what = _extract_field(lines, "What")
+        where = _extract_field(lines, "Where")
+        when_text = _extract_field(lines, "When")
+        cost = _extract_field(lines, "Cost")
+
+        cost_label = _infer_cost_label(cost)
+        cost_value = _extract_cost_value(cost)
+        days = _normalize_days(when_text)
+        activity_type = _infer_activity_type(name, what)
+
+        chunk_id = f"activity-{activity_id:03d}"
+        combined_text = "\n".join(
+            part for part in [name, what, where, when_text, cost] if part
+        ).strip()
+
+        metadata: Dict[str, Any] = {
+            "doc_type": "activity",
+            "chunk_id": chunk_id,
+            "activity_id": activity_id,
+            "activity_name": name,
+            "description": what,
+            "location": where,
+            "schedule": when_text,
+            "days": days,
+            "cost_raw": cost,
+            "cost_label": cost_label,
+            "cost_value": cost_value,
+            "activity_type": activity_type,
+            "aliases": _location_aliases(where),
+        }
+
+        chunks.append(ActivityChunk(chunk_id=chunk_id, text=combined_text, metadata=metadata))
+
+    return chunks

--- a/rag/parsing_master.py
+++ b/rag/parsing_master.py
@@ -1,0 +1,110 @@
+"""Parsing utilities for the master slides dataset."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+CHUNK_DIVIDER = re.compile(r"\n\*{5,}\s*\n", flags=re.MULTILINE)
+LESSON_PATTERN = re.compile(r"LESSON\s+(?P<num>\d+):\s*(?P<title>[^\n]+)", flags=re.IGNORECASE)
+SLIDE_PATTERN = re.compile(r"L(?P<lesson>\d+)-S(?P<slide>\d+)-G(?P<global>\d+)", flags=re.IGNORECASE)
+TITLE_PATTERN = re.compile(r"^Title:\s*(.+)$", flags=re.IGNORECASE | re.MULTILINE)
+CONTENT_PATTERN = re.compile(r"Content:\s*(.+)", flags=re.IGNORECASE | re.DOTALL)
+
+
+@dataclass
+class MasterChunk:
+    """Represents a single slide chunk along with structured metadata."""
+
+    chunk_id: str
+    text: str
+    metadata: Dict[str, Any]
+
+
+def _clean_lesson_title(raw_title: str) -> str:
+    title = raw_title.strip()
+    title = re.sub(r"\(\d+[^)]*\)$", "", title).strip()
+    return title
+
+
+def _extract_slide_title(chunk: str) -> str:
+    match = TITLE_PATTERN.search(chunk)
+    if match:
+        return match.group(1).strip()
+    # fallback for lesson description slides
+    desc_match = re.search(r"Lesson Description:\s*(.+)", chunk, flags=re.IGNORECASE)
+    if desc_match:
+        return desc_match.group(1).strip()
+    return ""
+
+
+def _extract_content(chunk: str) -> str:
+    match = CONTENT_PATTERN.search(chunk)
+    if match:
+        return match.group(1).strip()
+    # no explicit content block, return chunk minus markers
+    cleaned = re.sub(r"\+\+\+\s*", "", chunk)
+    cleaned = re.sub(r"\s{2,}", " ", cleaned)
+    return cleaned.strip()
+
+
+def _split_chunks(text: str) -> Iterable[str]:
+    for piece in CHUNK_DIVIDER.split(text):
+        cleaned = piece.strip()
+        if cleaned:
+            yield cleaned
+
+
+def parse_master_file(path: Path) -> List[MasterChunk]:
+    """Parse the master dataset into structured chunks."""
+
+    if not path.exists():
+        raise FileNotFoundError(f"Master dataset not found at {path}")
+
+    text = path.read_text(encoding="utf-8")
+    lesson_titles: Dict[int, str] = {}
+
+    chunks: List[MasterChunk] = []
+    for segment in _split_chunks(text):
+        lesson_match = LESSON_PATTERN.search(segment)
+        if lesson_match:
+            lesson_number = int(lesson_match.group("num"))
+            lesson_titles[lesson_number] = _clean_lesson_title(lesson_match.group("title"))
+
+        slide_match = SLIDE_PATTERN.search(segment)
+        if not slide_match:
+            continue
+
+        lesson_number = int(slide_match.group("lesson"))
+        slide_number = int(slide_match.group("slide"))
+        global_slide_number = int(slide_match.group("global"))
+        lesson_title = lesson_titles.get(lesson_number, "")
+
+        slide_title = _extract_slide_title(segment)
+        content = _extract_content(segment)
+        merged_text = "\n".join(
+            part for part in [f"Lesson {lesson_number}", f"Slide {slide_number}", slide_title, content] if part
+        ).strip()
+
+        lower_title = slide_title.lower()
+        do_not_reference_marker = "***DO NOT REFERENCE***" in segment.upper()
+        references_title = any(keyword in lower_title for keyword in ["reference", "references", "bibliography", "citations"])
+        do_not_reference = do_not_reference_marker or references_title
+        chunk_id = f"master-L{lesson_number:02d}-S{slide_number:02d}-G{global_slide_number:03d}"
+
+        metadata: Dict[str, Any] = {
+            "doc_type": "master",
+            "chunk_id": chunk_id,
+            "lesson_number": lesson_number,
+            "slide_number": slide_number,
+            "global_slide_number": global_slide_number,
+            "lesson_title": lesson_title,
+            "slide_title": slide_title,
+            "do_not_reference": do_not_reference,
+        }
+
+        chunks.append(MasterChunk(chunk_id=chunk_id, text=merged_text, metadata=metadata))
+
+    return chunks

--- a/rag/retriever.py
+++ b/rag/retriever.py
@@ -1,0 +1,198 @@
+"""Runtime retrieval helpers that connect to Qdrant via LlamaIndex."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Sequence
+
+from llama_index.core import Settings, VectorStoreIndex
+from llama_index.core.retrievers import VectorIndexRetriever
+from llama_index.embeddings.openai import OpenAIEmbedding
+from llama_index.vector_stores.qdrant import QdrantVectorStore
+from qdrant_client import QdrantClient
+
+from rag.config import RagConfig
+from rag.router import ActivityFilters, RouteDecision
+
+
+def _node_content(node: Any) -> str:
+    if hasattr(node, "get_content"):
+        try:
+            return node.get_content(metadata_mode="all")
+        except TypeError:
+            return node.get_content()
+    return getattr(node, "text", "")
+
+
+def _truncate(text: str, limit: int = 1200) -> str:
+    cleaned = text.strip()
+    if len(cleaned) <= limit:
+        return cleaned
+    return f"{cleaned[:limit].rstrip()}..."
+
+
+@dataclass
+class RetrievedChunk:
+    doc_type: str
+    text: str
+    metadata: Dict[str, Any]
+    score: Optional[float] = None
+
+    def label(self) -> str:
+        if self.doc_type == "master":
+            lesson = self.metadata.get("lesson_number")
+            slide = self.metadata.get("slide_number")
+            title = self.metadata.get("slide_title") or ""
+            return f"Lesson {lesson} Slide {slide}: {title}".strip()
+        activity_name = self.metadata.get("activity_name", "Activity")
+        location = self.metadata.get("location", "")
+        return f"{activity_name} ({location})".strip()
+
+    def reference(self) -> Optional[str]:
+        if self.doc_type == "master":
+            lesson = self.metadata.get("lesson_number")
+            lesson_title = self.metadata.get("lesson_title") or "Untitled lesson"
+            slide = self.metadata.get("slide_number")
+            slide_title = self.metadata.get("slide_title") or "Untitled slide"
+            return f"Lesson {lesson}: {lesson_title} -> Slide {slide} ({slide_title})"
+        if self.doc_type == "activity":
+            activity_id = self.metadata.get("activity_id")
+            name = self.metadata.get("activity_name", "Activity")
+            location = self.metadata.get("location", "Location TBD")
+            schedule = self.metadata.get("schedule", "Schedule TBD")
+            cost = self.metadata.get("cost_raw", "Cost unknown")
+            return f"Activity {activity_id}: {name} — {location}, {schedule}, {cost}"
+        return None
+
+
+@dataclass
+class RetrievalResult:
+    master_chunks: Sequence[RetrievedChunk]
+    activity_chunks: Sequence[RetrievedChunk]
+
+    def _reference_sort_key(self, chunk: RetrievedChunk) -> tuple:
+        if chunk.doc_type == "master":
+            lesson = chunk.metadata.get("lesson_number") or 0
+            slide = chunk.metadata.get("slide_number") or 0
+            global_idx = chunk.metadata.get("global_slide_number") or 0
+            return (0, int(lesson), int(slide), int(global_idx))
+        if chunk.doc_type == "activity":
+            activity_id = chunk.metadata.get("activity_id") or 0
+            return (1, int(activity_id))
+        return (2, 0)
+
+    def build_prompt_context(self) -> str:
+        sections: List[str] = []
+        if self.master_chunks:
+            sections.append(self._format_section("Master slides", self.master_chunks))
+        if self.activity_chunks:
+            sections.append(self._format_section("Local activities", self.activity_chunks))
+        return "\n\n".join(sections)
+
+    def _format_section(self, title: str, chunks: Sequence[RetrievedChunk]) -> str:
+        lines = [f"{title}:"]
+        for chunk in chunks:
+            lines.append(f"- {chunk.label()}\n  {_truncate(chunk.text)}")
+        return "\n".join(lines)
+
+    def references(self) -> List[str]:
+        refs: List[str] = []
+        seen = set()
+        chunks = list(self.master_chunks) + list(self.activity_chunks)
+        for chunk in sorted(chunks, key=self._reference_sort_key):
+            citation = chunk.reference()
+            if citation and citation not in seen:
+                seen.add(citation)
+                refs.append(citation)
+        return refs
+
+
+class RagRetriever:
+    """Builds query engines for the master and activity indexes."""
+
+    def __init__(self, config: RagConfig) -> None:
+        self.config = config
+        Settings.embed_model = OpenAIEmbedding(model=config.embedding_model, api_key=config.openai_api_key)
+        self.client = QdrantClient(url=config.qdrant_url, api_key=config.qdrant_api_key)
+        self.master_index = self._build_index(config.master_collection)
+        self.activity_index = self._build_index(config.activities_collection)
+
+    def _build_index(self, collection_name: str) -> VectorStoreIndex:
+        vector_store = QdrantVectorStore(client=self.client, collection_name=collection_name)
+        return VectorStoreIndex.from_vector_store(vector_store=vector_store)
+
+    def _build_retriever(self, index: VectorStoreIndex, top_k: int) -> VectorIndexRetriever:
+        return index.as_retriever(similarity_top_k=top_k)
+
+    def retrieve_master(self, query: str, top_k: Optional[int] = None) -> List[RetrievedChunk]:
+        retriever = self._build_retriever(self.master_index, top_k or self.config.master_top_k)
+        nodes = retriever.retrieve(query)
+        return [
+            RetrievedChunk(
+                doc_type=node.node.metadata.get("doc_type", "master"),
+                text=_node_content(node.node),
+                metadata=node.node.metadata,
+                score=node.score,
+            )
+            for node in nodes
+            if not node.node.metadata.get("do_not_reference", False)
+        ]
+
+    def retrieve_activities(
+        self,
+        query: str,
+        *,
+        filters: Optional[ActivityFilters] = None,
+        top_k: Optional[int] = None,
+    ) -> List[RetrievedChunk]:
+        base_top_k = top_k or self.config.activity_top_k
+        retrieval_top_k = max(base_top_k * 2, 8) if filters and filters.days else base_top_k
+        retriever = self._build_retriever(self.activity_index, retrieval_top_k)
+
+        nodes = retriever.retrieve(query)
+        wrapped = [
+            RetrievedChunk(
+                doc_type=node.node.metadata.get("doc_type", "activity"),
+                text=_node_content(node.node),
+                metadata=node.node.metadata,
+                score=node.score,
+            )
+            for node in nodes
+        ]
+        if filters:
+            wrapped = self._apply_activity_filters(wrapped, filters)
+        return wrapped[:base_top_k]
+
+    def _apply_activity_filters(self, chunks: List[RetrievedChunk], filters: ActivityFilters) -> List[RetrievedChunk]:
+        def matches(chunk: RetrievedChunk) -> bool:
+            metadata = chunk.metadata
+            if filters.cost_label:
+                if metadata.get("cost_label") != filters.cost_label:
+                    return False
+            if filters.activity_type:
+                if metadata.get("activity_type") != filters.activity_type:
+                    return False
+            if filters.location:
+                location = (metadata.get("location") or "").lower()
+                aliases = [alias.lower() for alias in metadata.get("aliases", [])]
+                target = filters.location.lower()
+                if target not in location and target not in aliases:
+                    return False
+            if filters.days:
+                chunk_days = [day.lower() for day in metadata.get("days", [])]
+                if not any(day.lower() in chunk_days for day in filters.days):
+                    return False
+            return True
+
+        return [chunk for chunk in chunks if matches(chunk)]
+
+    def gather_context(self, query: str, decision: RouteDecision) -> RetrievalResult:
+        master_chunks: List[RetrievedChunk] = []
+        activity_chunks: List[RetrievedChunk] = []
+
+        if decision.use_master:
+            master_chunks = self.retrieve_master(query)
+        if decision.use_activities:
+            activity_chunks = self.retrieve_activities(query, filters=decision.activity_filters)
+
+        return RetrievalResult(master_chunks=master_chunks, activity_chunks=activity_chunks)

--- a/rag/router.py
+++ b/rag/router.py
@@ -1,0 +1,133 @@
+"""Keyword-based routing logic for deciding which indexes to query."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import List, Optional
+
+DAY_PATTERN = re.compile(
+    r"\b(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday|Weekend|Weekends?)\b",
+    flags=re.IGNORECASE,
+)
+
+ACTIVITY_KEYWORDS = [
+    "class",
+    "classes",
+    "activity",
+    "activities",
+    "things to do",
+    "something to do",
+    "local",
+    "near me",
+    "community",
+    "program",
+    "resource",
+    "resources",
+    "activity list",
+    "group",
+    "club",
+    "schedule",
+    "where can i go",
+    "something nearby",
+    "in my area",
+    "pickleball",
+    "yoga",
+    "pilates",
+    "walk with others",
+    "walking group",
+    "kayak",
+    "swim",
+    "pool",
+]
+
+LOCATION_HINTS = {
+    "crystal": "fernwood",
+    "crystal pool": "fernwood",
+    "fairfield": "fairfield",
+    "fernwood": "fernwood",
+    "downtown": "downtown",
+    "victoria": "victoria",
+    "oaklands": "oaklands",
+    "oak bay": "oak bay",
+    "uplands": "oak bay",
+    "james bay": "james bay",
+    "victoria west": "victoria west",
+    "ocean river": "downtown",
+    "saanich": "saanich",
+    "cedar hill": "cedar hill",
+    "online": "online",
+    "home": "online",
+}
+
+TYPE_KEYWORDS = {
+    "yoga": ["yoga"],
+    "walking": ["walk", "walking", "hike"],
+    "pickleball": ["pickleball"],
+    "dance": ["dance", "zumba"],
+    "strength": ["strength", "weights", "resistance", "band", "pilates"],
+    "aquatic": ["aqua", "pool", "swim"],
+    "kayaking": ["kayak"],
+}
+
+
+@dataclass
+class ActivityFilters:
+    cost_label: Optional[str] = None
+    days: Optional[List[str]] = None
+    location: Optional[str] = None
+    activity_type: Optional[str] = None
+
+    def has_filters(self) -> bool:
+        return any([self.cost_label, self.days, self.location, self.activity_type])
+
+
+@dataclass
+class RouteDecision:
+    use_master: bool = True
+    use_activities: bool = False
+    activity_filters: Optional[ActivityFilters] = None
+    needs_location_clarification: bool = False
+
+
+class QueryRouter:
+    """Simple heuristic router for selecting between master vs. activity indexes."""
+
+    def route(self, user_input: str) -> RouteDecision:
+        lowered = user_input.lower()
+        use_activities = any(keyword in lowered for keyword in ACTIVITY_KEYWORDS)
+
+        activity_filters = ActivityFilters()
+
+        recognized_location = False
+        if "free" in lowered:
+            activity_filters.cost_label = "free"
+
+        day_matches = [match.group(1).capitalize() for match in DAY_PATTERN.finditer(user_input)]
+        if day_matches:
+            activity_filters.days = list(dict.fromkeys(day_matches))
+
+        for hint, normalized in LOCATION_HINTS.items():
+            if hint in lowered:
+                activity_filters.location = normalized
+                use_activities = True
+                recognized_location = True
+                break
+
+        for act_type, keywords in TYPE_KEYWORDS.items():
+            if any(keyword in lowered for keyword in keywords):
+                activity_filters.activity_type = act_type
+                use_activities = True
+                break
+
+        if not activity_filters.has_filters():
+            activity_filters = None
+
+        route = RouteDecision(
+            use_master=True,
+            use_activities=use_activities,
+            activity_filters=activity_filters,
+            needs_location_clarification=use_activities and not recognized_location,
+        )
+
+        return route

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 python-dotenv
 openai>=1.0.0
+llama-index
+qdrant-client

--- a/tests/test_rag_routing.py
+++ b/tests/test_rag_routing.py
@@ -1,0 +1,148 @@
+"""Tests covering the RAG routing + context injection logic using stubs."""
+# These tests stub the retriever/router/LLM so we can verify the RAG routing workflow without hitting Qdrant or OpenAI.
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+import unittest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+try:
+    from main import CoachAgent
+    from rag.retriever import RetrievedChunk, RetrievalResult
+    from rag.router import QueryRouter, RouteDecision
+
+    RAG_AVAILABLE = True
+except ModuleNotFoundError as exc:
+    if "llama_index" in str(exc):
+        RAG_AVAILABLE = False
+    else:
+        raise
+
+
+if not RAG_AVAILABLE:
+
+    class RagRoutingTests(unittest.TestCase):
+        @unittest.skip("llama-index not installed; skip RAG routing tests")
+        def test_placeholder(self) -> None:
+            pass
+
+
+else:
+
+    class StubCompletion:
+        def __init__(self, text: str) -> None:
+            message = type("Msg", (), {"content": text})
+            choice = type("Choice", (), {"message": message()})
+            self.choices = [choice()]
+
+    class StubChatCompletions:
+        def __init__(self, client: "StubClient") -> None:
+            self._client = client
+
+        def create(self, **kwargs):
+            self._client.calls.append(kwargs)
+            return StubCompletion("Stub reply")
+
+    class StubChat:
+        def __init__(self, client: "StubClient") -> None:
+            self.completions = StubChatCompletions(client)
+
+    class StubClient:
+        def __init__(self) -> None:
+            self.calls = []
+            self.chat = StubChat(self)
+
+    class StubRetriever:
+        def __init__(self, result: RetrievalResult) -> None:
+            self.result = result
+            self.received_queries = []
+            self.received_decisions = []
+
+        def gather_context(self, query: str, decision: RouteDecision) -> RetrievalResult:
+            self.received_queries.append(query)
+            self.received_decisions.append(decision)
+            return self.result
+
+    class StubRouter(QueryRouter):  # type: ignore[misc]
+        def __init__(self, decision: RouteDecision) -> None:
+            self.decision = decision
+            self.inputs = []
+
+        def route(self, user_input: str) -> RouteDecision:  # type: ignore[override]
+            self.inputs.append(user_input)
+            return self.decision
+
+    def _activity_chunk() -> RetrievedChunk:
+        metadata = {
+            "doc_type": "activity",
+            "activity_id": 1,
+            "activity_name": "Walking Group",
+            "location": "Waterfront",
+            "schedule": "Wednesdays",
+            "cost_raw": "Free",
+        }
+        return RetrievedChunk(doc_type="activity", text="Group walk details", metadata=metadata)
+
+    def _master_chunk() -> RetrievedChunk:
+        metadata = {
+            "doc_type": "master",
+            "lesson_number": 1,
+            "lesson_title": "Why Physical Activity Matters",
+            "slide_number": 3,
+            "slide_title": "What is physical activity?",
+        }
+        return RetrievedChunk(doc_type="master", text="Physical activity definition", metadata=metadata)
+
+    @unittest.skipUnless(RAG_AVAILABLE, "llama-index not installed; skip RAG routing tests")
+    class RagRoutingTests(unittest.TestCase):
+        def _build_agent(self, result: RetrievalResult, decision: RouteDecision) -> tuple[CoachAgent, StubClient]:
+            stub_client = StubClient()
+            retriever = StubRetriever(result)
+            router = StubRouter(decision)
+            agent = CoachAgent(client=stub_client, model="fake-model", retriever=retriever, router=router)
+            return agent, stub_client
+
+        def test_activity_context_injected_when_router_requests(self) -> None:
+            # Test 1: when user asks for local resources, the activity index should be used
+            result = RetrievalResult(master_chunks=[], activity_chunks=[_activity_chunk()])
+            decision = RouteDecision(use_master=False, use_activities=True)
+            agent, client = self._build_agent(result, decision)
+
+            agent.generate_response("Any local walking groups?")
+
+            self.assertTrue(client.calls, "Expected chat client to be invoked")
+            context_block = client.calls[0]["messages"][1]["content"]
+            self.assertIn("Local activities:", context_block)
+            self.assertIn("Walking Group", context_block)
+
+        def test_master_context_injected_for_general_query(self) -> None:
+            # Test 2: general knowledge queries should pull in master slides for support
+            result = RetrievalResult(master_chunks=[_master_chunk()], activity_chunks=[])
+            decision = RouteDecision(use_master=True, use_activities=False)
+            agent, client = self._build_agent(result, decision)
+
+            agent.generate_response("Why does physical activity matter?")
+
+            context_block = client.calls[0]["messages"][1]["content"]
+            self.assertIn("Master slides:", context_block)
+            self.assertIn("Lesson 1", context_block)
+
+        def test_citations_added_when_user_requests_sources(self) -> None:
+            # Test 3: explicit source requests should append formatted references
+            result = RetrievalResult(master_chunks=[_master_chunk()], activity_chunks=[])
+            decision = RouteDecision(use_master=True, use_activities=False)
+            agent, _ = self._build_agent(result, decision)
+
+            reply = agent.generate_response("Remind me what physical activity means (show sources).")
+
+            self.assertIn("From your modules", reply)
+            self.assertIn("Lesson 1:", reply)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
-Wired LlamaIndex + Qdrant retrieval into main.py, including routing logic, source formatting, short replies, and CLI prompt updates
-Built the rag/ package (config, parsers, router, retriever, ingest script) plus RAG-focused unit tests
-Expanded the activity dataset (Oak Bay/Saanich/etc.), added metadata aliases, and ensured sequential numbering so location filters match user queries
-Added new startup sanity check and “show sources” behavior (citations on demand, fallback prompts)
-Introduced Fernwood/Oak Bay/Uplands routing clarifications and hub prompts when locations aren’t recognized
-Updated requirements and test coverage; confirmed .venv/bin/python -m pytest tests/test_rag_routing.py passes