### PR TITLE
Show wearable data append in web frontend on done event

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -529,6 +529,7 @@ async function streamAssistantResponse(text) {
         if (event.type === "token") {
           botBubble.textContent += event.text;
         } else if (event.type === "done") {
+          botBubble.textContent = event.text;
           finalState = event.state;
         } else if (event.type === "error") {
           throw new Error(event.error || "Unknown error");


### PR DESCRIPTION
The done event carries the full final text including the wearable data block, but the web was ignoring event.text. Set botBubble content from event.text on done to match iOS app behaviour.